### PR TITLE
require path cleanup

### DIFF
--- a/lib/web_translate_it.rb
+++ b/lib/web_translate_it.rb
@@ -1,12 +1,13 @@
 # encoding: utf-8
-require File.join(File.dirname(__FILE__), 'web_translate_it', 'util')
-require File.join(File.dirname(__FILE__), 'web_translate_it', 'configuration')
-require File.join(File.dirname(__FILE__), 'web_translate_it', 'translation_file')
-require File.join(File.dirname(__FILE__), 'web_translate_it', 'auto_fetch')
-require File.join(File.dirname(__FILE__), 'web_translate_it', 'command_line')
-require File.join(File.dirname(__FILE__), 'web_translate_it', 'project')
-require File.join(File.dirname(__FILE__), 'web_translate_it', 'tasks')
-require File.join(File.dirname(__FILE__), 'web_translate_it', 'server')
+require 'rubygems'
+require 'web_translate_it/util'
+require 'web_translate_it/configuration'
+require 'web_translate_it/translation_file'
+require 'web_translate_it/auto_fetch'
+require 'web_translate_it/command_line'
+require 'web_translate_it/project'
+require 'web_translate_it/tasks'
+require 'web_translate_it/server'
 
 module WebTranslateIt
   

--- a/lib/web_translate_it/project.rb
+++ b/lib/web_translate_it/project.rb
@@ -3,7 +3,7 @@ module WebTranslateIt
   class Project
     
     def self.fetch_info(api_key)
-      puts "Gathering project's information..."
+      puts "Gathering project's information..." unless Object.const_defined?(:Spec)
       begin
         WebTranslateIt::Util.http_connection do |http|
           request = Net::HTTP::Get.new("/api/projects/#{api_key}.yaml")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,2 @@
 require File.dirname(__FILE__) + '/../lib/web_translate_it'
-# $:.unshift File.dirname(__FILE__) + '/../lib'
-# Dir[File.join(File.dirname(__FILE__), '../vendor/*/lib')].each do |path|
-#   $:.unshift path
-# end
+require 'spec'

--- a/spec/web_translate_it/configuration_spec.rb
+++ b/spec/web_translate_it/configuration_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require 'spec_helper'
 
 describe WebTranslateIt::Configuration do
   describe "#initialize" do

--- a/spec/web_translate_it/translation_file_spec.rb
+++ b/spec/web_translate_it/translation_file_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require 'spec_helper'
 
 describe WebTranslateIt::TranslationFile do
   

--- a/spec/web_translate_it/util_spec.rb
+++ b/spec/web_translate_it/util_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+require 'spec_helper'
 
 describe WebTranslateIt::Util do
     

--- a/spec/web_translate_it_spec.rb
+++ b/spec/web_translate_it_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require 'spec/spec_helper'
 
 module WebTranslateIt
   class I18n


### PR DESCRIPTION
Hi,

i have changed the absolute require path's to relative one's. Not a big deal but looks cleaner and f.ex the spec helper is only included once through this.

Besides i got two errors when running the specs(before and after my changes):  

```
NoMethodError in 'WebTranslateIt::TranslationFile#fetch should prepare a HTTP request and get a 200 OK if the language file is stale' undefined method `>=' for nil:NilClass
translation_file.rb:38:in `fetch'
translation_file_spec.rb:21:
```

Another thing is the 'mocking' of  WebTranslateIt::Configuration::Rails in the config specs throwing undefined errros when run alone.

Merci pour le gem,

george
