### PR TITLE
Fix links to github in WTI console footer.

### DIFF
--- a/lib/web_translate_it/views/index.erb
+++ b/lib/web_translate_it/views/index.erb
@@ -46,8 +46,8 @@
         <div class="contact">
           <p>
             <a href="http://docs.webtranslateit.com">Documentation</a><br/>
-            <a href="http://github.com/AtelierConvivialite/web_translate_it">Source</a><br/>
-            <a href="http://github.com/AtelierConvivialite/web_translate_it/issues">Issues</a><br/>
+            <a href="https://github.com/AtelierConvivialite/webtranslateit/">Source</a><br/>
+            <a href="https://github.com/AtelierConvivialite/webtranslateit/issues">Issues</a><br/>
             <a href="http://twitter.com/webtranslateit">Twitter</a>
           </p>
         </div>


### PR DESCRIPTION
Hey Édouard,

I noticed a couple of links were broken in the WTI console footer. Here's a patch.

Cheers,
James.
