### PR TITLE
Fixes deprecation warnings from #in?

### DIFF
--- a/lib/web_translate_it.rb
+++ b/lib/web_translate_it.rb
@@ -23,7 +23,7 @@ module WebTranslateIt
     return if config.ignore_locales.include?(locale)
     config.logger.debug { "   Fetching #{locale} language file(s) from WebTranslateIt" } if config.logger
     WebTranslateIt::Connection.new(config.api_key) do |http|
-      config.files.find_all{ |file| file.locale.in?(locale, I18n.locale) }.each do |file|
+      config.files.find_all{ |file| file.locale.in?([locale, I18n.locale]) }.each do |file|
         response = file.fetch(http)
       end
     end


### PR DESCRIPTION
```
DEPRECATION WARNING: Calling #in? with multiple arguments is deprecated, please 
pass in an object that responds to #include? instead.
```

This fixes the above deprecation warning.
