### PR TITLE
Support ignoring files when pulling via configuration file

### DIFF
--- a/examples/.wti
+++ b/examples/.wti
@@ -9,6 +9,10 @@ api_key: SECRET
 # Or if you prefer a list of locales to sync with WebTranslateIt:
 # needed_locales: [en, fr, it]
 
+# Optional: files not to sync with WebTranslateIt.
+# Takes an array of globs.
+# ignore_files: ['somefile*.csv']
+
 # Optional
 # before_pull: "echo 'some unix command'"   # Command executed before pulling files
 # after_pull:  "touch tmp/restart.txt"      # Command executed after pulling files

--- a/lib/web_translate_it/command_line.rb
+++ b/lib/web_translate_it/command_line.rb
@@ -307,6 +307,10 @@ api_key: #{api_key}
 # Or if you prefer a list of locales to sync with WebTranslateIt:
 # needed_locales: #{project_info["target_locales"].map {|locale| locale["code"]}.to_s}
 
+# Optional: files not to sync with WebTranslateIt.
+# Takes an array of globs.
+# ignore_files: ['somefile*.csv']
+
 # Optional
 # before_pull: "echo 'some unix command'"   # Command executed before pulling files
 # after_pull:  "touch tmp/restart.txt"      # Command executed after pulling files


### PR DESCRIPTION
We track files in our WTI project that aren't necessary for some clients. E.g., our iPhone app uses lproj files, our web server uses yaml files, and we also have translated CSV files for coordinating marketing copy. I wanted the ability to pull into the iPhone app while ignoring the files for other purposes. This seems to work well.
