### PR TITLE
Parse ERB in configuration file

### DIFF
--- a/lib/web_translate_it/configuration.rb
+++ b/lib/web_translate_it/configuration.rb
@@ -18,7 +18,6 @@ module WebTranslateIt
       self.path           = root_path
       self.logger         = logger
       if File.exists?(File.expand_path(path_to_config_file, self.path))
-        configuration       = YAML.load_file(File.expand_path(path_to_config_file, self.path))
         self.api_key        = configuration['api_key']
         self.before_pull    = configuration['before_pull']
         self.after_pull     = configuration['after_pull']
@@ -84,6 +83,16 @@ module WebTranslateIt
       elsif defined?(RAILS_DEFAULT_LOGGER)
         RAILS_DEFAULT_LOGGER
       end
+    end
+
+    def configuration
+      @configuration ||= YAML.load(parse_erb_in_configuration)
+    end
+
+    private
+
+    def parse_erb_in_configuration
+      ERB.new(File.read(File.expand_path(path_to_config_file, self.path))).result
     end
   end
 end

--- a/web_translate_it.gemspec
+++ b/web_translate_it.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "web_translate_it" 
-  s.version     = "2.3.0"
+  s.version     = "2.3.1"
   s.summary     = "A CLI to sync locale files with WebTranslateIt.com."
   s.description = "A gem to push and pull language files to WebTranslateIt.com."
   s.email       = "edouard@atelierconvivialite.com"


### PR DESCRIPTION
I prefer not to store my API token in source control, however I would
like to keep the `.wti` file in my repo.

Inserting some ERB into the config allows me to use an environment
variable to store the token and parse it when loading the config.
