### PR TITLE
Allow to specify multiple projects

### DIFF
--- a/bin/wti
+++ b/bin/wti
@@ -6,7 +6,7 @@ require 'trollop'
 require 'web_translate_it'
 
 show_commands = <<-EOS
-Usage: wti <command> [options]+ <filename>
+Usage: wti <command> --project <project> [options]+ <filename>
 
 The most commonly used wti commands are:
    pull        Pull target language file(s)
@@ -20,6 +20,14 @@ The most commonly used wti commands are:
    init        Configure your project to sync
 
 See `wti <command> --help` for more information on a specific command.
+
+Project should be configured in your .wti file as:
+test_project:
+  api_key: xxxxx
+
+You can also provide default project for pull command as:
+default:
+  api_key: xxxxx
 
 [options] are:
 EOS
@@ -39,6 +47,7 @@ command_options = case command
 wti pull [filename] - Pull target language file(s)
 [options] are:
 EOS
+      opt :project, "Project name configured in your wti file", :type => :string, :short => "-p"
       opt :locale, "ISO code of locale(s) to pull", :type => :string
       opt :all,    "Pull all files"
       opt :force,  "Force pull (bypass conditional requests to WTI)"
@@ -51,6 +60,7 @@ EOS
 wti push [filename] - Push master language file(s)
 [options] are:
 EOS
+      opt :project, "Project name configured in your wti file", :type => :string, :short => "-p"
       opt :locale, "ISO code of locale(s) to push", :type => :string
       opt :target, "Upload all target files"
       opt :force,  "Force push (bypass conditional requests to WTI)"
@@ -66,6 +76,7 @@ EOS
   when "add"
     Trollop::options do
       banner "wti add filename - Create and push a new master language file"
+      opt :project, "Project name configured in your wti file", :type => :string, :short => "-p"
       opt :low_priority, "WTI will process this file with a low priority"
       opt :config, "Path to a configuration file", :short => "-c", :default => ".wti"
       opt :debug,  "Display debug information"
@@ -73,36 +84,42 @@ EOS
   when "rm"
     Trollop::options do
       banner "wti rm filename - Delete a master language file"
+      opt :project, "Project name configured in your wti file", :type => :string, :short => "-p"
       opt :config, "Path to a configuration file", :short => "-c", :default => ".wti"
       opt :debug,  "Display debug information"
     end
   when "addlocale"
     Trollop::options do
       banner "wti addlocale localename - Add a new locale to the project"
+      opt :project, "Project name configured in your wti file", :type => :string, :short => "-p"
       opt :config, "Path to a configuration file", :short => "-c", :default => ".wti"
       opt :debug,  "Display debug information"
     end
   when "rmlocale"
     Trollop::options do
       banner "wti rmlocale localename Delete a locale from the project"
+      opt :project, "Project name configured in your wti file", :type => :string, :short => "-p"
       opt :config, "Path to a configuration file", :short => "-c", :default => ".wti"
       opt :debug,  "Display debug information"
     end
   when "status"
     Trollop::options do
       banner "wti status - Fetch and display project statistics"
+      opt :project, "Project name configured in your wti file", :type => :string, :short => "-p"
       opt :config, "Path to a configuration file", :short => "-c", :default => ".wti"
       opt :debug,  "Display debug information"
     end
   when "init"
     Trollop::options do
       banner "wti init [api_token] - Configure your project to sync"
+      opt :project, "Project name configured in your wti file", :type => :string, :short => "-p"
       opt :config, "Path to a configuration file", :short => "-c", :default => ".wti"
       opt :debug,  "Display debug information"
     end
   when "match"
     Trollop::options do
       banner "wti match - Display matching of local files with File Manager"
+      opt :project, "Project name configured in your wti file", :type => :string, :short => "-p"
       opt :config, "Path to a configuration file", :short => "-c", :default => ".wti"
       opt :debug,  "Display debug information"
     end
@@ -114,6 +131,11 @@ EOS
       Trollop::die "Unknown subcommand #{command.inspect}"
     end
   end
+
+if command_options[:project].nil? && command != "pull"
+  puts StringUtil.failure("\nPlease provide project name!")
+  exit 1
+end
 
 begin
   WebTranslateIt::Connection.turn_debug_on if command_options.debug

--- a/lib/web_translate_it/command_line.rb
+++ b/lib/web_translate_it/command_line.rb
@@ -25,7 +25,7 @@ module WebTranslateIt
         else
           message = "Gathering information"
         end
-        throb { print "  #{message}"; self.configuration = WebTranslateIt::Configuration.new(project_path, configuration_file_path); print " #{message} on #{self.configuration.project_name}"; }
+        throb { print "  #{message}"; self.configuration = WebTranslateIt::Configuration.new(project_path, configuration_file_path, command_options[:project]); print " #{message} on #{self.configuration.project_name}"; }
       end
       success = self.send(command)
       exit 1 if !success

--- a/lib/web_translate_it/configuration.rb
+++ b/lib/web_translate_it/configuration.rb
@@ -15,12 +15,21 @@ module WebTranslateIt
     attr_accessor :logger, :before_pull, :after_pull, :before_push, :after_push, :project_name, :path_to_config_file
     
     # Load configuration file from the path.
-    def initialize(root_path = Rails.root, path_to_config_file = ".wti")
+    def initialize(root_path = Rails.root, path_to_config_file = ".wti", project = nil)
       self.path_to_config_file = path_to_config_file
       self.path           = root_path
       self.logger         = logger
       if File.exists?(File.expand_path(path_to_config_file, self.path))
-        self.api_key        = configuration['api_key']
+        if project
+          if configuration[project]
+            self.api_key    = configuration[project]['api_key']
+          else
+            puts StringUtil.failure("\nCan't find the #{project} project configured in .wti file")
+            exit(1)
+          end
+        else
+          self.api_key      = configuration['default']['api_key']
+        end
         self.before_pull    = configuration['before_pull']
         self.after_pull     = configuration['after_pull']
         self.before_push    = configuration['before_push']


### PR DESCRIPTION
Multiple projects can now be specified within one repository. All of the commands besides `pull` require the `--project` flag to be provided with project name specified in the `.wti` file. It is also possible to set a default project for pull command.

The .wti file should be structured as:

``` yaml
project_1:
  api_key: xxxx
project_2:
  api_key: xxxx
default:
  api_key: xxxx
```
