### PR TITLE
Added return codes doc to WTI status

### DIFF
--- a/bin/wti
+++ b/bin/wti
@@ -97,7 +97,7 @@ EOS
     end
   when "status"
     Optimist::options do
-      banner "wti status - Fetch and display project statistics"
+      banner "wti status - Fetch and display project statistics. Returns 100 if untranslated strings or 101 if unproof read strings exist in project."
       opt :config, "Path to a configuration file", short: "-c", default: ".wti"
       opt :debug,  "Display debug information"
     end


### PR DESCRIPTION
`wti status` prints the state of the project to the terminal.

The command returns different exit values for the state when the project is not fully translated or proof read.

This PR just adds those status codes to `wti status --help`