### PR TITLE
docs: Make it clearer that --locale uses #split

### DIFF
--- a/bin/wti
+++ b/bin/wti
@@ -40,7 +40,7 @@ command_options = case command
 wti pull [filename] - Pull target language file(s)
 [options] are:
 EOS
-      opt :locale, "ISO code of locale(s) to pull", type: :string
+      opt :locale, "ISO code of locale(s) to pull, space-separated", type: :string
       opt :all,    "Pull all files"
       opt :force,  "Force pull (bypass conditional requests to WTI)"
       opt :config, "Path to a configuration file", short: "-c", default: ".wti"
@@ -52,7 +52,7 @@ EOS
 wti push [filename] - Push master language file(s)
 [options] are:
 EOS
-      opt :locale, "ISO code of locale(s) to push", type: :string
+      opt :locale, "ISO code of locale(s) to push, space-separated", type: :string
       opt :target, "Upload all target files"
       opt :force,  "Force push (bypass conditional requests to WTI)"
       opt :low_priority, "WTI will process this file with a low priority"


### PR DESCRIPTION
This PR tries to clarify that the option for locales should be used like:

```
wti push -l 'en sv'
```