### PR TITLE
Hooks improvements

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+## Version 2.5.4 / 2022-03-08
+
+* Better support for `before_pull`, `after_pull`, `before_push`, `after_push` hooks. They now display the command output, and write an error message if the exit status of the command was not successful.
+
 ## Version 2.5.3 / 2022-02-04
 
 * Properly fix ruby compatibility issues.

--- a/lib/web_translate_it/command_line.rb
+++ b/lib/web_translate_it/command_line.rb
@@ -36,7 +36,7 @@ module WebTranslateIt
     def pull
       complete_success = true
       STDOUT.sync = true
-      `#{configuration.before_pull}` if configuration.before_pull
+      before_pull_hook
       # Selecting files to pull
       files = []
       fetch_locales_to_pull.each do |locale|
@@ -70,15 +70,37 @@ module WebTranslateIt
         threads.each { |thread| thread.join }
         time = Time.now - time
         puts "Pulled #{files.size} files at #{(files.size/time).round} files/sec, using #{n_threads} threads."
-        `#{configuration.after_pull}` if configuration.after_pull
+        after_pull_hook
         complete_success
       end
     end
-    
+
+    def before_pull_hook
+      if configuration.before_pull
+        output = `#{configuration.before_pull}`
+        if $?.success?
+          puts output
+        else
+          abort 'Error: exit code for before_pull command is not zero'
+        end
+      end
+    end
+
+    def after_pull_hook
+      if configuration.after_pull
+        output = `#{configuration.after_pull}`
+        if $?.success?
+          puts output
+        else
+          abort 'Error: exit code for after_pull command is not zero'
+        end
+      end
+    end
+
     def push
       complete_success = true
       STDOUT.sync = true
-      `#{configuration.before_push}` if configuration.before_push
+      before_push_hook
       WebTranslateIt::Connection.new(configuration.api_key) do |http|
         fetch_locales_to_push(configuration).each do |locale|
           if parameters.any?
@@ -96,8 +118,30 @@ module WebTranslateIt
           end
         end
       end
-      `#{configuration.after_push}` if configuration.after_push
+      after_push_hook
       complete_success
+    end
+
+    def before_push_hook
+      if configuration.before_push
+        output = `#{configuration.before_push}`
+        if $?.success?
+          puts output
+        else
+          abort 'Error: exit code for before_push command is not zero'
+        end
+      end
+    end
+
+    def after_push_hook
+      if configuration.after_push
+        output = `#{configuration.after_push}`
+        if $?.success?
+          puts output
+        else
+          abort 'Error: exit code for after_push command is not zero'
+        end
+      end
     end
     
     def add

--- a/web_translate_it.gemspec
+++ b/web_translate_it.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "web_translate_it"
-  s.version     = "2.5.3"
+  s.version     = "2.5.4"
   s.summary     = "A CLI to sync locale files with WebTranslateIt.com."
   s.description = "A gem to push and pull language files to WebTranslateIt.com."
   s.email       = "edouard@atelierconvivialite.com"


### PR DESCRIPTION
This PR adds improvements to the `before_pull`, `after_pull`, `before_push`, `after_push` hooks. They now display the command output, and write an error message if the exit status of the command was not successful.