### PR TITLE
Display error message for `before_pull`, `after_pull`, `before_push`, `after_push` hooks

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+## Edge
+
+* Display error message for `before_pull`, `after_pull`, `before_push`, `after_push` hooks.
+
 ## Version 2.6.0 / 2022-03-08
 
 * Code cleaning using Rubocop.

--- a/lib/web_translate_it/command_line.rb
+++ b/lib/web_translate_it/command_line.rb
@@ -85,7 +85,7 @@ module WebTranslateIt
       if $?.success?
         puts output
       else
-        abort 'Error: exit code for before_pull command is not zero'
+        abort "Error: before_pull command exited with: #{output}"
       end
     end
 
@@ -96,7 +96,7 @@ module WebTranslateIt
       if $?.success?
         puts output
       else
-        abort 'Error: exit code for after_pull command is not zero'
+        abort "Error: after_pull command exited with: #{output}"
       end
     end
 
@@ -132,7 +132,7 @@ module WebTranslateIt
       if $?.success?
         puts output
       else
-        abort 'Error: exit code for before_push command is not zero'
+        abort "Error: before_push command exited with: #{output}"
       end
     end
 
@@ -143,7 +143,7 @@ module WebTranslateIt
       if $?.success?
         puts output
       else
-        abort 'Error: exit code for after_push command is not zero'
+        abort "Error: after_push command exited with: #{output}"
       end
     end
 


### PR DESCRIPTION
This PR displays the output for hooks when the exit status is not successful.