### PR TITLE
Specify minimum multipart_post version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     web_translate_it (2.7.1)
       multi_json
-      multipart-post (~> 2.0)
+      multipart-post (~> 2.2)
       optimist (~> 3.0)
 
 GEM

--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+## Edge
+
+* Specify a minimum version for dependency `multipart_post`.
+
 ## Version 2.7.1 / 2022-10-14
 
 * Potential fix potential for issue `uninitialized constant WebTranslateIt::TranslationFile::Multipart`.

--- a/web_translate_it.gemspec
+++ b/web_translate_it.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['history.md', 'license', 'readme.md', 'version', 'examples/**/*', 'lib/**/*', 'generators/**/*', 'bin/**/*', 'man/**/*']
 
   s.add_dependency 'multi_json'
-  s.add_dependency 'multipart-post', '~> 2.0'
+  s.add_dependency 'multipart-post', '~> 2.2'
   s.add_dependency 'optimist', '~> 3.0'
 
   s.rdoc_options     = ['--main', 'readme.md']


### PR DESCRIPTION
User reported upgrading wti using `bundle update web_translate --conservative`. It left `multipart_post` at version 2.1.1 and wti was not working correctly. Our minimum version is 2.2.x.