### PR TITLE
Relax dependency on multipart_post to ~> 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     web_translate_it (2.7.2)
       multi_json
-      multipart-post (~> 2.2)
+      multipart-post (~> 2.0)
       optimist (~> 3.0)
 
 GEM

--- a/lib/web_translate_it.rb
+++ b/lib/web_translate_it.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'multipart/post'
 require 'yaml'
 require 'erb'
 require 'net/http'

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -96,7 +96,7 @@ module WebTranslateIt
       if File.exist?(file_path)
         if force || (remote_checksum != local_checksum)
           File.open(file_path) do |file|
-            params = {'file' => Multipart::Post::UploadIO.new(file, 'text/plain', file.path), 'merge' => merge, 'ignore_missing' => ignore_missing, 'label' => label, 'low_priority' => low_priority, 'minor_changes' => minor_changes}
+            params = {'file' => ::Multipart::Post::UploadIO.new(file, 'text/plain', file.path), 'merge' => merge, 'ignore_missing' => ignore_missing, 'label' => label, 'low_priority' => low_priority, 'minor_changes' => minor_changes}
             params['name'] = destination_path unless destination_path.nil?
             params['rename_others'] = rename_others
             request = Net::HTTP::Put::Multipart.new(api_url, params)

--- a/web_translate_it.gemspec
+++ b/web_translate_it.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['history.md', 'license', 'readme.md', 'version', 'examples/**/*', 'lib/**/*', 'generators/**/*', 'bin/**/*', 'man/**/*']
 
   s.add_dependency 'multi_json'
-  s.add_dependency 'multipart-post', '~> 2.2'
+  s.add_dependency 'multipart-post', '~> 2.0'
   s.add_dependency 'optimist', '~> 3.0'
 
   s.rdoc_options     = ['--main', 'readme.md']


### PR DESCRIPTION
Made sure the error `uninitialized constant WebTranslateIt::TranslationFile::Multipart. Did you mean? Multipartable` doesn’t happen by using `require multipart/post` and `::Multipart` instead of `Multipart`