### PR TITLE
Remove `low-priority` argument as in `wti push --low-priority` and `wti add --low-priority`

### DIFF
--- a/bin/wti
+++ b/bin/wti
@@ -55,7 +55,7 @@ when 'push'
     opt :locale, 'ISO code of locale(s) to push, space-separated', type: :string
     opt :target, 'Upload all target files'
     opt :force,  'Force push (bypass conditional requests to WTI)'
-    opt :low_priority, 'WTI will process this file with a low priority'
+    opt :low_priority, 'Deprecated: option to process this file with a low priority'
     opt :merge, 'Force WTI to merge this file'
     opt :ignore_missing, 'Force WTI to not obsolete missing strings'
     opt :minor, 'Minor Changes. When pushing a master file, prevents target translations to be flagged as `to_verify`.'
@@ -67,7 +67,7 @@ when 'push'
 when 'add'
   Optimist.options do
     banner 'wti add filename - Create and push a new master language file'
-    opt :low_priority, 'WTI will process this file with a low priority'
+    opt :low_priority, 'Deprecated: option to process this file with a low priority'
     opt :config, 'Path to a configuration file', short: '-c', default: '.wti'
     opt :debug,  'Display debug information'
   end

--- a/lib/web_translate_it/command_line.rb
+++ b/lib/web_translate_it/command_line.rb
@@ -101,6 +101,7 @@ module WebTranslateIt
     end
 
     def push # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+      puts 'The `--low-priority` option in `wti push --low-priority` was removed and does nothing' if command_options.low_priority
       complete_success = true
       $stdout.sync = true
       before_push_hook
@@ -115,7 +116,7 @@ module WebTranslateIt
             puts "Couldn't find any local files registered on WebTranslateIt to push."
           else
             files.each do |file|
-              success = file.upload(http, command_options[:merge], command_options.ignore_missing, command_options.label, command_options.low_priority, command_options[:minor], command_options.force)
+              success = file.upload(http, command_options[:merge], command_options.ignore_missing, command_options.label, command_options[:minor], command_options.force)
               complete_success = false unless success
             end
           end
@@ -161,7 +162,7 @@ module WebTranslateIt
         if to_add.any?
           to_add.each do |param|
             file = TranslationFile.new(nil, param.gsub(/ /, '\\ '), nil, configuration.api_key)
-            success = file.create(http, command_options.low_priority)
+            success = file.create(http)
             complete_success = false unless success
           end
         else

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -87,7 +87,7 @@ module WebTranslateIt
     # rubocop:todo Metrics/ParameterLists
     # rubocop:todo Metrics/MethodLength
     # rubocop:todo Metrics/AbcSize
-    def upload(http_connection, merge = false, ignore_missing = false, label = nil, low_priority = false, minor_changes = false, force = false, rename_others = false, destination_path = nil) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/ParameterLists, Metrics/PerceivedComplexity
+    def upload(http_connection, merge = false, ignore_missing = false, label = nil, minor_changes = false, force = false, rename_others = false, destination_path = nil) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/ParameterLists, Metrics/PerceivedComplexity
       success = true
       tries ||= 3
       display = []
@@ -96,7 +96,7 @@ module WebTranslateIt
       if File.exist?(file_path)
         if force || (remote_checksum != local_checksum)
           File.open(file_path) do |file|
-            params = {'file' => ::Multipart::Post::UploadIO.new(file, 'text/plain', file.path), 'merge' => merge, 'ignore_missing' => ignore_missing, 'label' => label, 'low_priority' => low_priority, 'minor_changes' => minor_changes}
+            params = {'file' => ::Multipart::Post::UploadIO.new(file, 'text/plain', file.path), 'merge' => merge, 'ignore_missing' => ignore_missing, 'label' => label, 'minor_changes' => minor_changes}
             params['name'] = destination_path unless destination_path.nil?
             params['rename_others'] = rename_others
             request = Net::HTTP::Put::Multipart.new(api_url, params)
@@ -139,7 +139,7 @@ module WebTranslateIt
     # Note that the request might or might not eventually be acted upon, as it might be disallowed when processing
     # actually takes place. This is due to the fact that language file imports are handled by background processing.
     #
-    def create(http_connection, low_priority = false) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
+    def create(http_connection) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       tries ||= 3
       display = []
@@ -147,7 +147,7 @@ module WebTranslateIt
       display.push "#{StringUtil.checksumify(local_checksum.to_s)}..[     ]"
       if File.exist?(file_path)
         File.open(file_path) do |file|
-          request = Net::HTTP::Post::Multipart.new(api_url_for_create, {'name' => file_path, 'file' => Multipart::Post::UploadIO.new(file, 'text/plain', file.path), 'low_priority' => low_priority})
+          request = Net::HTTP::Post::Multipart.new(api_url_for_create, {'name' => file_path, 'file' => Multipart::Post::UploadIO.new(file, 'text/plain', file.path)})
           WebTranslateIt::Util.add_fields(request)
           display.push Util.handle_response(http_connection.request(request))
           puts ArrayUtil.to_columns(display)

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,6 @@ Append `--help` for each command for more information. For instance:
       -l, --locale=<s>        ISO code of locale(s) to push
       -t, --target            Upload all target files
       -f, --force             Force push (bypass conditional requests to WTI)
-      -o, --low-priority      WTI will process this file with a low priority
       -m, --merge             Force WTI to merge this file
       -i, --ignore-missing    Force WTI to not obsolete missing strings
       -n, --minor             Minor Changes. When pushing a master file, prevents


### PR DESCRIPTION
All the file imports in WebTranslateIt.com are now top priority.