### PR TITLE
wti now works with `multipart_post = 2.0.0` AND `multipart_post >= 2.2.0`

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+## Edge
+
+* wti now works with `multipart_post = 2.0.0` AND `multipart_post >= 2.2.0`.
+
 ## Version 2.7.4 / 2022-11-01
 
 * Remove `low-priority` argument as in `wti push --low-priority` and `wti add --low-priority`. All the file imports in WebTranslateIt.com are now top priority.

--- a/lib/web_translate_it.rb
+++ b/lib/web_translate_it.rb
@@ -1,5 +1,4 @@
 require 'fileutils'
-require 'multipart/post'
 require 'yaml'
 require 'erb'
 require 'net/http'

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -147,7 +147,7 @@ module WebTranslateIt
       display.push "#{StringUtil.checksumify(local_checksum.to_s)}..[     ]"
       if File.exist?(file_path)
         File.open(file_path) do |file|
-          request = Net::HTTP::Post::Multipart.new(api_url_for_create, {'name' => file_path, 'file' => Multipart::Post::UploadIO.new(file, 'text/plain', file.path)})
+          request = ::Net::HTTP::Post::Multipart.new(api_url_for_create, {'name' => file_path, 'file' => Multipart::Post::UploadIO.new(file, 'text/plain', file.path)})
           WebTranslateIt::Util.add_fields(request)
           display.push Util.handle_response(http_connection.request(request))
           puts ArrayUtil.to_columns(display)


### PR DESCRIPTION
multipart_post 2.2 included some API changes. It is possible to use `require 'multipart/post` but that doesn't work when using multipart_post 2.0.

It is not an option to require multipart_post >= 2.2 because some important gems, like fastlane, depend on older versions.