### PR TITLE
Don’t rescue SSL Errors.

### DIFF
--- a/history.md
+++ b/history.md
@@ -3,6 +3,7 @@
 * Remove dependency on `multipart_post`. #255
 * Add frozen string litteral comments. #251
 * Bump minimum ruby version to ruby 2.7.
+* Don’t rescue SSL errors. #257
 
 ## Version 2.8.3 / 2023-04-19
 

--- a/lib/web_translate_it/connection.rb
+++ b/lib/web_translate_it/connection.rb
@@ -35,14 +35,8 @@ module WebTranslateIt
         @@http_connection = http.start
         yield @@http_connection if block_given?
       rescue OpenSSL::SSL::SSLError
-        puts 'Unable to verify SSL certificate.'
-        http = Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).new('webtranslateit.com', 443)
-        http.set_debug_output($stderr) if @@debug
-        http.use_ssl      = true
-        http.open_timeout = http.read_timeout = 60
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        @@http_connection = http.start
-        yield @@http_connection if block_given?
+        puts 'Error: Unable to verify SSL certificate.'
+        exit 1
       rescue StandardError
         puts $ERROR_INFO
       end


### PR DESCRIPTION
This is potentially a breaking change for some users having SSL configuration issues. This should probably be released as wti 3.0.0