### PR TITLE
Limit the amount of threads used

### DIFF
--- a/lib/web_translate_it/command_line.rb
+++ b/lib/web_translate_it/command_line.rb
@@ -60,7 +60,7 @@ module WebTranslateIt
         time = Time.now
         threads = []
         n_threads = [(files.size.to_f / 3).ceil, 10].min
-        files.each_slice(n_threads).each do |file_array|
+        files.each_slice((files.size.to_f/n_threads).round).each do |file_array|
           next if file_array.empty?
 
           threads << Thread.new(file_array) do |f_array|


### PR DESCRIPTION
Before this change https://github.com/webtranslateit/webtranslateit/pull/258/files the CLI used to spawn maximum of 10 threads. With the `each_slice` implementation, if you have a lot of files, you end up spawning too many threads and most likely receive errors

```
Failed to open TCP connection to webtranslateit.com:443 (Too many open files - socket(2) for "webtranslateit.com" port 443)
An error occured: Too many open files @ rb_sysopen -
```

Consider a scenario with 1000 files. When `n_threads` is set to be 10, each iteration of the `files.each_slice` operation will process a chunk containing 10 items. This results in 100 iterations overall, leading to the creation of a total of 100 threads.

The proposed changes split the array to equal size parts, like the previous `chunks` method.