### PR TITLE
Upgrade RuboCop RSpec gem in lockfile

### DIFF
--- a/.rubocop_common.yml
+++ b/.rubocop_common.yml
@@ -79,7 +79,7 @@ Style/HashSyntax:
 
 
 # - RSpec Cops --------------------------------------------------------------------------------------------------------
-# N.B. In some future version of ruboco-rspec IgnoredMetadata can be used instead of Exclude
+# N.B. In some future version of rubocop-rspec IgnoredMetadata can be used instead of Exclude
 
 RSpec/NamedSubject:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
+    ast (2.4.3)
     coderay (1.1.3)
     diff-lcs (1.5.1)
     docile (1.4.0)
@@ -31,8 +31,9 @@ GEM
     guard-rubocop (1.5.0)
       guard (~> 2.0)
       rubocop (< 2.0)
-    json (2.9.1)
+    json (2.10.2)
     language_server-protocol (3.17.0.4)
+    lint_roller (1.1.0)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -45,9 +46,10 @@ GEM
       shellany (~> 0.0)
     optimist (3.2.0)
     parallel (1.26.3)
-    parser (3.3.7.0)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
+    prism (1.4.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -70,20 +72,23 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.0)
-    rubocop (1.71.1)
+    rubocop (1.75.1)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
+      rubocop-ast (>= 1.43.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.0)
-      parser (>= 3.3.1.0)
-    rubocop-rspec (3.4.0)
-      rubocop (~> 1.61)
+    rubocop-ast (1.43.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-rspec (3.5.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
     shellany (0.0.1)
     simplecov (0.22.0)
@@ -115,4 +120,4 @@ DEPENDENCIES
   web_translate_it!
 
 BUNDLED WITH
-   2.5.4
+   2.6.6


### PR DESCRIPTION
...and fix a spelling error in a comment.

About that comment, the feature is now in, but the configuration currently does not utilize that feature. Perhaps the comment can go? Or, investigate using the feature. https://github.com/rubocop/rubocop-rspec/blob/e85969d6b5627fe4a98e8571d5556b4dddd51144/lib/rubocop/cop/rspec/describe_class.rb#L10