### PR TITLE
Refactor Connection to eliminate class variables (#254)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    web_translate_it (3.2.0)
+    web_translate_it (3.2.1)
       multi_json
       optimist (~> 3.0)
 

--- a/history.md
+++ b/history.md
@@ -1,3 +1,8 @@
+## Version 3.2.1 / 2026-03-02
+
+* Refactor `Connection` class to eliminate class variables. #254
+* Fix `find_all` to guard against non-2xx API responses. #355
+
 ## Version 3.2.0 / 2026-01-14
 
 * Add `wti diff` command.

--- a/lib/web_translate_it.rb
+++ b/lib/web_translate_it.rb
@@ -34,9 +34,9 @@ module WebTranslateIt
     return if config.ignore_locales.include?(locale)
 
     config.logger&.debug { "   Fetching #{locale} language file(s) from WebTranslateIt" }
-    WebTranslateIt::Connection.new(config.api_key) do |http|
+    WebTranslateIt::Connection.new(config.api_key) do |conn|
       config.files.find_all { |file| file.locale.in?([locale, I18n.locale]) }.each do |file|
-        file.fetch(http)
+        file.fetch(conn.http_connection)
       end
     end
   end

--- a/lib/web_translate_it/command_line.rb
+++ b/lib/web_translate_it/command_line.rb
@@ -68,9 +68,9 @@ module WebTranslateIt
           next if file_array.empty?
 
           threads << Thread.new(file_array) do |f_array|
-            WebTranslateIt::Connection.new(configuration.api_key) do |http|
+            WebTranslateIt::Connection.new(configuration.api_key) do |conn|
               f_array.each do |file|
-                success = file.fetch(http, command_options.force)
+                success = file.fetch(conn.http_connection, command_options.force)
                 complete_success = false unless success
               end
             end
@@ -111,7 +111,7 @@ module WebTranslateIt
       complete_success = true
       $stdout.sync = true
       before_push_hook
-      WebTranslateIt::Connection.new(configuration.api_key) do |http|
+      WebTranslateIt::Connection.new(configuration.api_key) do |conn|
         fetch_locales_to_push(configuration).each do |locale|
           files = if parameters.any?
             configuration.files.find_all { |file| parameters.include?(file.file_path) }.sort { |a, b| a.file_path <=> b.file_path }
@@ -122,7 +122,7 @@ module WebTranslateIt
             puts "Couldn't find any local files registered on WebTranslateIt to push."
           else
             files.each do |file|
-              success = file.upload(http, command_options[:merge], command_options.ignore_missing, command_options.label, command_options[:minor], command_options.force)
+              success = file.upload(conn.http_connection, command_options[:merge], command_options.ignore_missing, command_options.label, command_options[:minor], command_options.force)
               complete_success = false unless success
             end
           end
@@ -157,7 +157,7 @@ module WebTranslateIt
     def diff # rubocop:todo Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       complete_success = true
       $stdout.sync = true
-      WebTranslateIt::Connection.new(configuration.api_key) do |http| # rubocop:todo Metrics/BlockLength
+      WebTranslateIt::Connection.new(configuration.api_key) do |conn| # rubocop:todo Metrics/BlockLength
         files = if parameters.any?
           configuration.files.find_all { |file| parameters.include?(file.file_path) }.sort { |a, b| a.file_path <=> b.file_path }
         else
@@ -168,7 +168,7 @@ module WebTranslateIt
         else
           files.each do |file|
             if File.exist?(file.file_path)
-              remote_content = file.fetch_remote_content(http)
+              remote_content = file.fetch_remote_content(conn.http_connection)
               if remote_content
                 temp_file = Tempfile.new('wti')
                 temp_file.write(remote_content)
@@ -198,13 +198,13 @@ module WebTranslateIt
         puts 'Usage: wti add path/to/master_file_1 path/to/master_file_2 ...'
         exit
       end
-      WebTranslateIt::Connection.new(configuration.api_key) do |http|
+      WebTranslateIt::Connection.new(configuration.api_key) do |conn|
         added = configuration.files.find_all { |file| file.locale == configuration.source_locale }.to_set { |file| File.expand_path(file.file_path) }
         to_add = parameters.reject { |param| added.include?(File.expand_path(param)) }
         if to_add.any?
           to_add.each do |param|
             file = TranslationFile.new(nil, param.gsub(/ /, '\\ '), nil, configuration.api_key)
-            success = file.create(http)
+            success = file.create(conn.http_connection)
             complete_success = false unless success
           end
         else
@@ -222,14 +222,14 @@ module WebTranslateIt
         puts 'Usage: wti rm path/to/master_file_1 path/to/master_file_2 ...'
         exit
       end
-      WebTranslateIt::Connection.new(configuration.api_key) do |http| # rubocop:todo Metrics/BlockLength
+      WebTranslateIt::Connection.new(configuration.api_key) do |conn| # rubocop:todo Metrics/BlockLength
         parameters.each do |param|
           next unless Util.ask_yes_no("Are you sure you want to delete the master file #{param}?\nThis will also delete its target files and translations.", false)
 
           files = configuration.files.find_all { |file| file.file_path == param }
           if files.any?
             files.each do |master_file|
-              master_file.delete(http)
+              master_file.delete(conn.http_connection)
               # delete files
               if File.exist?(master_file.file_path)
                 success = File.delete(master_file.file_path)
@@ -265,10 +265,10 @@ module WebTranslateIt
       end
       source = parameters[0]
       destination = parameters[1]
-      WebTranslateIt::Connection.new(configuration.api_key) do |http|
+      WebTranslateIt::Connection.new(configuration.api_key) do |conn|
         if Util.ask_yes_no("Are you sure you want to move the master file #{source} and its target files?", true)
           configuration.files.find_all { |file| file.file_path == source }.each do |master_file|
-            master_file.upload(http, false, false, nil, false, true, true, destination)
+            master_file.upload(conn.http_connection, false, false, nil, false, true, true, destination)
             # move master file
             if File.exist?(source)
               success = File.rename(source, destination) if File.exist?(source)
@@ -283,7 +283,7 @@ module WebTranslateIt
             end
             configuration.reload
             configuration.files.find_all { |file| file.master_id == master_file.id }.each do |target_file|
-              success = target_file.fetch(http)
+              success = target_file.fetch(conn.http_connection)
               complete_success = false unless success
             end
             puts StringUtil.success('All done.') if complete_success
@@ -302,8 +302,8 @@ module WebTranslateIt
       end
       parameters.each do |param|
         print StringUtil.success("Adding locale #{param.upcase}... ")
-        WebTranslateIt::Connection.new(configuration.api_key) do
-          WebTranslateIt::Project.create_locale(param)
+        WebTranslateIt::Connection.new(configuration.api_key) do |conn|
+          WebTranslateIt::Project.create_locale(conn, param)
         end
         puts 'Done.'
       end
@@ -320,8 +320,8 @@ module WebTranslateIt
         next unless Util.ask_yes_no("Are you certain you want to delete the locale #{param.upcase}?\nThis will also delete its files and translations.", false)
 
         print StringUtil.success("Deleting locale #{param.upcase}... ")
-        WebTranslateIt::Connection.new(configuration.api_key) do
-          WebTranslateIt::Project.delete_locale(param)
+        WebTranslateIt::Connection.new(configuration.api_key) do |conn|
+          WebTranslateIt::Project.delete_locale(conn, param)
         end
         puts 'Done.'
       end

--- a/lib/web_translate_it/connection.rb
+++ b/lib/web_translate_it/connection.rb
@@ -4,36 +4,36 @@ module WebTranslateIt
 
   class Connection
 
-    @@api_key = nil
-    @@http_connection = nil
-    @@debug = false
+    @debug = false
+
+    class << self
+
+      attr_reader :debug
+
+    end
+
+    attr_reader :api_key, :http_connection
 
     #
     # Initialize and yield a HTTPS Keep-Alive connection to WebTranslateIt.com
     #
     # Usage:
     #
-    # WebTranslateIt::Connection.new(api_key) do
-    #   # do something with Connection.api_key and Connection.http_connection
-    # end
-    #
-    # Or:
-    #
-    # WebTranslateIt::Connection.new(api_key) do |http_connection|
-    #   http_connection.request(request)
+    # WebTranslateIt::Connection.new(api_key) do |connection|
+    #   connection.http_connection.request(request)
     # end
     #
     def initialize(api_key) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      @@api_key = api_key
+      @api_key = api_key
       proxy = ENV['http_proxy'] ? URI.parse(ENV['http_proxy']) : Struct.new(:host, :port, :user, :password).new
       http = Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).new('webtranslateit.com', 443)
       http.use_ssl      = true
       http.open_timeout = http.read_timeout = 60
-      http.set_debug_output($stderr) if @@debug
+      http.set_debug_output($stderr) if self.class.debug
       begin
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        @@http_connection = http.start
-        yield @@http_connection if block_given?
+        @http_connection = http.start
+        yield self if block_given?
       rescue OpenSSL::SSL::SSLError
         puts 'Error: Unable to verify SSL certificate.'
         exit 1
@@ -43,15 +43,7 @@ module WebTranslateIt
     end
 
     def self.turn_debug_on
-      @@debug = true
-    end
-
-    def self.api_key
-      @@api_key
-    end
-
-    def self.http_connection
-      @@http_connection
+      @debug = true
     end
 
   end

--- a/lib/web_translate_it/project.rb
+++ b/lib/web_translate_it/project.rb
@@ -8,10 +8,10 @@ module WebTranslateIt
       success = true
       tries ||= 3
       begin
-        WebTranslateIt::Connection.new(api_key) do |http|
+        WebTranslateIt::Connection.new(api_key) do |conn|
           request = Net::HTTP::Get.new("/api/projects/#{api_key}")
           WebTranslateIt::Util.add_fields(request)
-          response = http.request(request)
+          response = conn.http_connection.request(request)
           return response.body if response.is_a?(Net::HTTPSuccess)
 
           puts 'An error occured while fetching the project information:'
@@ -37,10 +37,10 @@ module WebTranslateIt
       success = true
       tries ||= 3
       begin
-        WebTranslateIt::Connection.new(api_key) do |http|
+        WebTranslateIt::Connection.new(api_key) do |conn|
           request = Net::HTTP::Get.new(url)
           WebTranslateIt::Util.add_fields(request)
-          return Util.handle_response(http.request(request), true)
+          return Util.handle_response(conn.http_connection.request(request), true)
         end
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
@@ -54,14 +54,14 @@ module WebTranslateIt
       success
     end
 
-    def self.create_locale(locale_code) # rubocop:todo Metrics/MethodLength
+    def self.create_locale(connection, locale_code) # rubocop:todo Metrics/MethodLength
       success = true
       tries ||= 3
       begin
-        request = Net::HTTP::Post.new("/api/projects/#{Connection.api_key}/locales")
+        request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/locales")
         WebTranslateIt::Util.add_fields(request)
         request.set_form_data({'id' => locale_code}, ';')
-        Util.handle_response(Connection.http_connection.request(request), true)
+        Util.handle_response(connection.http_connection.request(request), true)
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
         if (tries -= 1).positive?
@@ -74,13 +74,13 @@ module WebTranslateIt
       success
     end
 
-    def self.delete_locale(locale_code) # rubocop:todo Metrics/MethodLength
+    def self.delete_locale(connection, locale_code) # rubocop:todo Metrics/MethodLength
       success = true
       tries ||= 3
       begin
-        request = Net::HTTP::Delete.new("/api/projects/#{Connection.api_key}/locales/#{locale_code}")
+        request = Net::HTTP::Delete.new("/api/projects/#{connection.api_key}/locales/#{locale_code}")
         WebTranslateIt::Util.add_fields(request)
-        Util.handle_response(Connection.http_connection.request(request), true)
+        Util.handle_response(connection.http_connection.request(request), true)
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
         if (tries -= 1).positive?

--- a/lib/web_translate_it/string.rb
+++ b/lib/web_translate_it/string.rb
@@ -5,7 +5,7 @@ module WebTranslateIt
   class String # rubocop:todo Metrics/ClassLength
 
     attr_accessor :id, :key, :plural, :type, :dev_comment, :word_count, :status, :category, :labels, :file,
-                  :created_at, :updated_at, :translations, :new_record
+                  :created_at, :updated_at, :translations, :new_record, :connection
 
     # Initialize a new WebTranslateIt::String
     #
@@ -21,8 +21,9 @@ module WebTranslateIt
     #
     # to instantiate a new String with a source and target translation.
 
-    def initialize(params = {}) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def initialize(params = {}, connection: nil) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
       params.stringify_keys!
+      self.connection   = connection
       self.id           = params['id'] || nil
       self.key          = params['key'] || nil
       self.plural       = params['plural'] || nil
@@ -51,11 +52,11 @@ module WebTranslateIt
     #
     # to find and instantiate an array of String which key is like `product_name_123`.
 
-    def self.find_all(params = {}) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def self.find_all(connection, params = {}) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
       success = true
       tries ||= 3
       params.stringify_keys!
-      url = "/api/projects/#{Connection.api_key}/strings"
+      url = "/api/projects/#{connection.api_key}/strings"
       url += "?#{HashUtil.to_params('filters' => params)}" unless params.empty?
 
       request = Net::HTTP::Get.new(url)
@@ -63,11 +64,11 @@ module WebTranslateIt
       begin
         strings = []
         while request
-          response = Connection.http_connection.request(request)
+          response = connection.http_connection.request(request)
           return [] unless response.code.to_i < 400
 
           JSON.parse(response.body).each do |string_response|
-            string = WebTranslateIt::String.new(string_response)
+            string = WebTranslateIt::String.new(string_response, connection: connection)
             string.new_record = false
             strings.push(string)
           end
@@ -106,16 +107,16 @@ module WebTranslateIt
     # to find and instantiate the String which ID is `1234`.
     #
 
-    def self.find(id) # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
+    def self.find(connection, id) # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
       success = true
       tries ||= 3
-      request = Net::HTTP::Get.new("/api/projects/#{Connection.api_key}/strings/#{id}")
+      request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/strings/#{id}")
       WebTranslateIt::Util.add_fields(request)
       begin
-        response = Connection.http_connection.request(request)
+        response = connection.http_connection.request(request)
         return nil if response.code.to_i == 404
 
-        string = WebTranslateIt::String.new(JSON.parse(response.body))
+        string = WebTranslateIt::String.new(JSON.parse(response.body), connection: connection)
         string.new_record = false
         return string
       rescue Timeout::Error
@@ -158,10 +159,10 @@ module WebTranslateIt
     def delete # rubocop:todo Metrics/MethodLength
       success = true
       tries ||= 3
-      request = Net::HTTP::Delete.new("/api/projects/#{Connection.api_key}/strings/#{id}")
+      request = Net::HTTP::Delete.new("/api/projects/#{connection.api_key}/strings/#{id}")
       WebTranslateIt::Util.add_fields(request)
       begin
-        Util.handle_response(Connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.http_connection.request(request), true, true)
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
         if (tries -= 1).positive?
@@ -191,14 +192,15 @@ module WebTranslateIt
       return translation if translation
       return nil if new_record
 
-      request = Net::HTTP::Get.new("/api/projects/#{Connection.api_key}/strings/#{id}/locales/#{locale}/translations")
+      request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/strings/#{id}/locales/#{locale}/translations")
       WebTranslateIt::Util.add_fields(request)
       begin
-        response = Util.handle_response(Connection.http_connection.request(request), true, true)
+        response = Util.handle_response(connection.http_connection.request(request), true, true)
         hash = JSON.parse(response)
         return nil if hash.empty?
 
         translation = WebTranslateIt::Translation.new(hash)
+        translation.connection = connection
         return translation
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
@@ -220,17 +222,18 @@ module WebTranslateIt
     def update # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       tries ||= 3
-      request = Net::HTTP::Put.new("/api/projects/#{Connection.api_key}/strings/#{id}")
+      request = Net::HTTP::Put.new("/api/projects/#{connection.api_key}/strings/#{id}")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
 
       translations.each do |translation|
         translation.string_id = id
+        translation.connection = connection
         translation.save
       end
 
       begin
-        Util.handle_response(Connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.http_connection.request(request), true, true)
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
         if (tries -= 1).positive?
@@ -249,11 +252,11 @@ module WebTranslateIt
     def create # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       tries ||= 3
-      request = Net::HTTP::Post.new("/api/projects/#{Connection.api_key}/strings")
+      request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/strings")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json(true)
       begin
-        response = JSON.parse(Util.handle_response(Connection.http_connection.request(request), true, true))
+        response = JSON.parse(Util.handle_response(connection.http_connection.request(request), true, true))
         self.id = response['id']
         self.new_record = false
         return true

--- a/lib/web_translate_it/term.rb
+++ b/lib/web_translate_it/term.rb
@@ -4,7 +4,7 @@ module WebTranslateIt
 
   class Term # rubocop:todo Metrics/ClassLength
 
-    attr_accessor :id, :text, :description, :created_at, :updated_at, :translations, :new_record
+    attr_accessor :id, :text, :description, :created_at, :updated_at, :translations, :new_record, :connection
 
     # Initialize a new WebTranslateIt::Term
     #
@@ -20,8 +20,9 @@ module WebTranslateIt
     #
     # to instantiate a new Term with a Term Translations in Spanish and French.
 
-    def initialize(params = {})
+    def initialize(params = {}, connection: nil) # rubocop:todo Metrics/AbcSize
       params.stringify_keys!
+      self.connection   = connection
       self.id           = params['id'] || nil
       self.text         = params['text'] || nil
       self.description  = params['description'] || nil
@@ -41,11 +42,11 @@ module WebTranslateIt
     #
     #  puts terms.inspect #=> An array of WebTranslateIt::Term objects
 
-    def self.find_all(params = {}) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def self.find_all(connection, params = {}) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
       success = true
       tries ||= 3
       params.stringify_keys!
-      url = "/api/projects/#{Connection.api_key}/terms"
+      url = "/api/projects/#{connection.api_key}/terms"
       url += "?#{HashUtil.to_params(params)}" unless params.empty?
 
       request = Net::HTTP::Get.new(url)
@@ -53,11 +54,11 @@ module WebTranslateIt
       begin
         terms = []
         while request
-          response = Connection.http_connection.request(request)
+          response = connection.http_connection.request(request)
           return [] unless response.code.to_i < 400
 
           JSON.parse(response.body).each do |term_response|
-            term = WebTranslateIt::Term.new(term_response)
+            term = WebTranslateIt::Term.new(term_response, connection: connection)
             term.new_record = false
             terms.push(term)
           end
@@ -96,16 +97,16 @@ module WebTranslateIt
     # to find and instantiate the Term which ID is `1234`.
     #
 
-    def self.find(term_id) # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
+    def self.find(connection, term_id) # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
       success = true
       tries ||= 3
-      request = Net::HTTP::Get.new("/api/projects/#{Connection.api_key}/terms/#{term_id}")
+      request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/terms/#{term_id}")
       WebTranslateIt::Util.add_fields(request)
       begin
-        response = Connection.http_connection.request(request)
+        response = connection.http_connection.request(request)
         return nil if response.code.to_i == 404
 
-        term = WebTranslateIt::Term.new(JSON.parse(response.body))
+        term = WebTranslateIt::Term.new(JSON.parse(response.body), connection: connection)
         term.new_record = false
         return term
       rescue Timeout::Error
@@ -148,10 +149,10 @@ module WebTranslateIt
     def delete # rubocop:todo Metrics/MethodLength
       success = true
       tries ||= 3
-      request = Net::HTTP::Delete.new("/api/projects/#{Connection.api_key}/terms/#{id}")
+      request = Net::HTTP::Delete.new("/api/projects/#{connection.api_key}/terms/#{id}")
       WebTranslateIt::Util.add_fields(request)
       begin
-        Util.handle_response(Connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.http_connection.request(request), true, true)
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
         if (tries -= 1).positive?
@@ -181,10 +182,10 @@ module WebTranslateIt
       return translation if translation
       return nil if new_record
 
-      request = Net::HTTP::Get.new("/api/projects/#{Connection.api_key}/terms/#{id}/locales/#{locale}/translations")
+      request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/terms/#{id}/locales/#{locale}/translations")
       WebTranslateIt::Util.add_fields(request)
       begin
-        response = Util.handle_response(Connection.http_connection.request(request), true, true)
+        response = Util.handle_response(connection.http_connection.request(request), true, true)
         array = JSON.parse(response)
         return nil if array.empty?
 
@@ -211,17 +212,18 @@ module WebTranslateIt
     def update # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       tries ||= 3
-      request = Net::HTTP::Put.new("/api/projects/#{Connection.api_key}/terms/#{id}")
+      request = Net::HTTP::Put.new("/api/projects/#{connection.api_key}/terms/#{id}")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
 
       translations.each do |translation|
         translation.term_id = id
+        translation.connection = connection
         translation.save
       end
 
       begin
-        Util.handle_response(Connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.http_connection.request(request), true, true)
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
         if (tries -= 1).positive?
@@ -237,12 +239,12 @@ module WebTranslateIt
     def create # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       tries ||= 3
-      request = Net::HTTP::Post.new("/api/projects/#{Connection.api_key}/terms")
+      request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/terms")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json(true)
 
       begin
-        response = JSON.parse(Util.handle_response(Connection.http_connection.request(request), true, true))
+        response = JSON.parse(Util.handle_response(connection.http_connection.request(request), true, true))
         self.id = response['id']
         self.new_record = false
         return true

--- a/lib/web_translate_it/term_translation.rb
+++ b/lib/web_translate_it/term_translation.rb
@@ -4,7 +4,7 @@ module WebTranslateIt
 
   class TermTranslation
 
-    attr_accessor :id, :locale, :text, :description, :status, :new_record, :term_id
+    attr_accessor :id, :locale, :text, :description, :status, :new_record, :term_id, :connection
 
     # Initialize a new WebTranslateIt::TermTranslation
     #
@@ -59,12 +59,12 @@ module WebTranslateIt
     def create # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       tries ||= 3
-      request = Net::HTTP::Post.new("/api/projects/#{Connection.api_key}/terms/#{term_id}/locales/#{locale}/translations")
+      request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/terms/#{term_id}/locales/#{locale}/translations")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
 
       begin
-        response = JSON.parse(Util.handle_response(Connection.http_connection.request(request), true, true))
+        response = JSON.parse(Util.handle_response(connection.http_connection.request(request), true, true))
         self.id = response['id']
         self.new_record = false
         return true
@@ -80,14 +80,14 @@ module WebTranslateIt
       success
     end
 
-    def update # rubocop:todo Metrics/MethodLength
+    def update # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       tries ||= 3
-      request = Net::HTTP::Put.new("/api/projects/#{Connection.api_key}/terms/#{id}/locales/#{locale}/translations/#{id}")
+      request = Net::HTTP::Put.new("/api/projects/#{connection.api_key}/terms/#{id}/locales/#{locale}/translations/#{id}")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
       begin
-        Util.handle_response(Connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.http_connection.request(request), true, true)
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
         if (tries -= 1).positive?

--- a/lib/web_translate_it/translation.rb
+++ b/lib/web_translate_it/translation.rb
@@ -4,7 +4,7 @@ module WebTranslateIt
 
   class Translation
 
-    attr_accessor :id, :locale, :text, :status, :created_at, :updated_at, :version, :string_id
+    attr_accessor :id, :locale, :text, :status, :created_at, :updated_at, :version, :string_id, :connection
 
     # Initialize a new WebTranslateIt::Translation
     #
@@ -39,11 +39,11 @@ module WebTranslateIt
 
     def save # rubocop:todo Metrics/MethodLength
       tries ||= 3
-      request = Net::HTTP::Post.new("/api/projects/#{Connection.api_key}/strings/#{string_id}/locales/#{locale}/translations")
+      request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/strings/#{string_id}/locales/#{locale}/translations")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
       begin
-        Util.handle_response(Connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.http_connection.request(request), true, true)
       rescue Timeout::Error
         puts 'Request timeout. Will retry in 5 seconds.'
         if (tries -= 1).positive?

--- a/spec/web_translate_it/string_spec.rb
+++ b/spec/web_translate_it/string_spec.rb
@@ -5,10 +5,7 @@ require 'spec_helper'
 describe WebTranslateIt::String do
   let(:api_key) { 'test_api_key' }
   let(:api_url) { "https://webtranslateit.com/api/projects/#{api_key}" }
-
-  before do
-    WebTranslateIt::Connection.new(api_key)
-  end
+  let!(:connection) { WebTranslateIt::Connection.new(api_key) }
 
   describe '#initialize' do
     it 'assigns api_key and many parameters' do
@@ -33,10 +30,10 @@ describe WebTranslateIt::String do
       stub_request(:delete, "#{api_url}/strings/1")
         .to_return(status: 200, body: '{"id": 1}')
 
-      string = described_class.new({'key' => 'bacon'})
+      string = described_class.new({'key' => 'bacon'}, connection: connection)
       string.save
       expect(string.id).not_to be_nil
-      string_fetched = described_class.find(string.id)
+      string_fetched = described_class.find(connection, string.id)
       expect(string_fetched).not_to be_nil
       expect(string_fetched).to be_a(described_class)
       expect(string_fetched.id).to eql string.id
@@ -53,11 +50,11 @@ describe WebTranslateIt::String do
       stub_request(:delete, "#{api_url}/strings/2")
         .to_return(status: 200, body: '{"id": 2}')
 
-      string = described_class.new({'key' => 'bacony'})
+      string = described_class.new({'key' => 'bacony'}, connection: connection)
       string.save
       string.key = 'bacon changed'
       string.save
-      string_fetched = described_class.find(string.id)
+      string_fetched = described_class.find(connection, string.id)
       expect(string_fetched.key).to eql 'bacon changed'
       string.delete
     end
@@ -85,9 +82,9 @@ describe WebTranslateIt::String do
       it 'creates a new String with Translation' do # rubocop:todo RSpec/MultipleExpectations
         translation1 = WebTranslateIt::Translation.new({'locale' => 'en', 'text' => 'Hello'})
         translation2 = WebTranslateIt::Translation.new({'locale' => 'fr', 'text' => 'Bonjour'})
-        string = described_class.new({'key' => 'bacon', 'translations' => [translation1, translation2]})
+        string = described_class.new({'key' => 'bacon', 'translations' => [translation1, translation2]}, connection: connection)
         string.save
-        string_fetched = described_class.find(string.id)
+        string_fetched = described_class.find(connection, string.id)
         expect(string_fetched.translation_for('en')).not_to be_nil
         expect(string_fetched.translation_for('en').text).to eql 'Hello'
         expect(string_fetched.translation_for('fr')).not_to be_nil
@@ -122,14 +119,14 @@ describe WebTranslateIt::String do
       it 'updates a String and save its Translation' do # rubocop:todo RSpec/MultipleExpectations
         translation1 = WebTranslateIt::Translation.new({'locale' => 'en', 'text' => 'Hello'})
         translation2 = WebTranslateIt::Translation.new({'locale' => 'fr', 'text' => 'Bonjour'})
-        string = described_class.new({'key' => 'bacon'})
+        string = described_class.new({'key' => 'bacon'}, connection: connection)
         string.save
-        string_fetched = described_class.find(string.id)
+        string_fetched = described_class.find(connection, string.id)
         expect(string_fetched.translation_for('fr')).to be_nil
 
         string_fetched.translations = [translation1, translation2]
         string_fetched.save
-        string_fetched = described_class.find(string.id)
+        string_fetched = described_class.find(connection, string.id)
         expect(string_fetched.translation_for('en')).not_to be_nil
         expect(string_fetched.translation_for('en').text).to eql 'Hello'
         expect(string_fetched.translation_for('fr')).not_to be_nil
@@ -149,13 +146,13 @@ describe WebTranslateIt::String do
       stub_request(:delete, "#{api_url}/strings/5")
         .to_return(status: 200, body: '{"id": 5}')
 
-      string = described_class.new({'key' => 'bacon'})
+      string = described_class.new({'key' => 'bacon'}, connection: connection)
       string.save
-      string_fetched = described_class.find(string.id)
+      string_fetched = described_class.find(connection, string.id)
       expect(string_fetched).not_to be_nil
 
       string_fetched.delete
-      expect(described_class.find(string.id)).to be_nil
+      expect(described_class.find(connection, string.id)).to be_nil
     end
   end
 
@@ -171,12 +168,12 @@ describe WebTranslateIt::String do
         .with(query: {'filters[key]' => 'three'})
         .to_return(status: 200, body: '[{"id": 1, "key": "one two three"}]')
 
-      strings = described_class.find_all({'key' => 'six'})
+      strings = described_class.find_all(connection, {'key' => 'six'})
       expect(strings.count).to be 2
       expect(strings[0].key).to eql 'four five six'
       expect(strings[1].key).to eql 'six seven eight'
 
-      strings = described_class.find_all({key: 'six'})
+      strings = described_class.find_all(connection, {key: 'six'})
       expect(strings.count).to be 2
       expect(strings[0].key).to eql 'four five six'
       expect(strings[1].key).to eql 'six seven eight'
@@ -190,11 +187,11 @@ describe WebTranslateIt::String do
         .with(query: {'filters[key]' => 'three'})
         .to_return(status: 200, body: '[{"id": 1, "key": "one two three"}]')
 
-      strings = described_class.find_all({'key' => 'eight'})
+      strings = described_class.find_all(connection, {'key' => 'eight'})
       expect(strings.count).to be 1
       expect(strings[0].key).to eql 'six seven eight'
 
-      strings = described_class.find_all({'key' => 'three'})
+      strings = described_class.find_all(connection, {'key' => 'three'})
       expect(strings.count).to be 1
       expect(strings[0].key).to eql 'one two three'
     end
@@ -206,7 +203,7 @@ describe WebTranslateIt::String do
           body: '["error", "No project found for this API token"]'
         )
 
-      strings = described_class.find_all
+      strings = described_class.find_all(connection)
       expect(strings).to eq([])
     end
   end
@@ -227,9 +224,9 @@ describe WebTranslateIt::String do
         .to_return(status: 200, body: '{"id": 6}')
 
       translation = WebTranslateIt::Translation.new({'locale' => 'en', 'text' => 'Hello'})
-      string = described_class.new({'key' => 'greetings', 'translations' => [translation]})
+      string = described_class.new({'key' => 'greetings', 'translations' => [translation]}, connection: connection)
       string.save
-      string_fetched = described_class.find(string.id)
+      string_fetched = described_class.find(connection, string.id)
       expect(string_fetched.translation_for('en')).not_to be_nil
       expect(string_fetched.translation_for('en').text).to eql 'Hello'
       expect(string_fetched.translation_for('fr')).to be_nil

--- a/spec/web_translate_it/term_spec.rb
+++ b/spec/web_translate_it/term_spec.rb
@@ -5,10 +5,7 @@ require 'spec_helper'
 describe WebTranslateIt::Term do
   let(:api_key) { 'test_api_key' }
   let(:api_url) { "https://webtranslateit.com/api/projects/#{api_key}" }
-
-  before do
-    WebTranslateIt::Connection.new(api_key)
-  end
+  let!(:connection) { WebTranslateIt::Connection.new(api_key) }
 
   describe '#initialize' do
     it 'assigns api_key and many parameters' do
@@ -33,10 +30,10 @@ describe WebTranslateIt::Term do
       stub_request(:delete, "#{api_url}/terms/1")
         .to_return(status: 200, body: '{"id": 1}')
 
-      term = described_class.new({'text' => 'Term', 'description' => 'A description'})
+      term = described_class.new({'text' => 'Term', 'description' => 'A description'}, connection: connection)
       term.save
       expect(term.id).not_to be_nil
-      term_fetched = described_class.find(term.id)
+      term_fetched = described_class.find(connection, term.id)
       expect(term_fetched).not_to be_nil
       expect(term_fetched).to be_a(described_class)
       expect(term_fetched.id).to eql term.id
@@ -53,11 +50,11 @@ describe WebTranslateIt::Term do
       stub_request(:delete, "#{api_url}/terms/2")
         .to_return(status: 200, body: '{"id": 2}')
 
-      term = described_class.new({'text' => 'Term 2', 'description' => 'A description'})
+      term = described_class.new({'text' => 'Term 2', 'description' => 'A description'}, connection: connection)
       term.save
       term.text = 'A Term'
       term.save
-      term_fetched = described_class.find(term.id)
+      term_fetched = described_class.find(connection, term.id)
       expect(term_fetched.text).to eql 'A Term'
       term.delete
     end
@@ -82,9 +79,9 @@ describe WebTranslateIt::Term do
         translation1 = WebTranslateIt::TermTranslation.new({'locale' => 'fr', 'text' => 'Bonjour'})
         translation2 = WebTranslateIt::TermTranslation.new({'locale' => 'fr', 'text' => 'Salut'})
 
-        term = described_class.new({'text' => 'Hello', 'translations' => [translation1, translation2]})
+        term = described_class.new({'text' => 'Hello', 'translations' => [translation1, translation2]}, connection: connection)
         term.save
-        term_fetched = described_class.find(term.id)
+        term_fetched = described_class.find(connection, term.id)
         expect(term_fetched.translation_for('fr')).not_to be_nil
         expect(term_fetched.translation_for('fr')[0].text).to eql 'Salut'
         expect(term_fetched.translation_for('fr')[1].text).to eql 'Bonjour'
@@ -114,14 +111,14 @@ describe WebTranslateIt::Term do
       it 'updates a Term and save its Translation' do # rubocop:todo RSpec/MultipleExpectations
         translation1 = WebTranslateIt::TermTranslation.new({'locale' => 'fr', 'text' => 'Bonjour'})
         translation2 = WebTranslateIt::TermTranslation.new({'locale' => 'fr', 'text' => 'Salut'})
-        term = described_class.new({'text' => 'Hi!'})
+        term = described_class.new({'text' => 'Hi!'}, connection: connection)
         term.save
-        term_fetched = described_class.find(term.id)
+        term_fetched = described_class.find(connection, term.id)
         expect(term_fetched.translation_for('fr')).to be_nil
 
         term_fetched.translations = [translation1, translation2]
         term_fetched.save
-        term_fetched = described_class.find(term.id)
+        term_fetched = described_class.find(connection, term.id)
         expect(term_fetched.translation_for('fr')).not_to be_nil
         expect(term_fetched.translation_for('fr')[0].text).to eql 'Salut'
         expect(term_fetched.translation_for('fr')[1].text).to eql 'Bonjour'
@@ -140,13 +137,13 @@ describe WebTranslateIt::Term do
       stub_request(:delete, "#{api_url}/terms/5")
         .to_return(status: 200, body: '{"id": 5}')
 
-      term = described_class.new({'text' => 'bacon'})
+      term = described_class.new({'text' => 'bacon'}, connection: connection)
       term.save
-      term_fetched = described_class.find(term.id)
+      term_fetched = described_class.find(connection, term.id)
       expect(term_fetched).not_to be_nil
 
       term_fetched.delete
-      term_fetched = described_class.find(term.id)
+      term_fetched = described_class.find(connection, term.id)
       expect(term_fetched).to be_nil
     end
   end
@@ -159,7 +156,7 @@ describe WebTranslateIt::Term do
           body: '[{"id": 10, "text": "greeting 1"}, {"id": 11, "text": "greeting 2"}, {"id": 12, "text": "greeting 3"}]'
         )
 
-      terms = described_class.find_all
+      terms = described_class.find_all(connection)
       expect(terms.count).to be 3
       expect(terms[0].text).to eql 'greeting 1'
       expect(terms[1].text).to eql 'greeting 2'
@@ -173,7 +170,7 @@ describe WebTranslateIt::Term do
           body: '["error", "No project found for this API token"]'
         )
 
-      terms = described_class.find_all
+      terms = described_class.find_all(connection)
       expect(terms).to eq([])
     end
   end

--- a/web_translate_it.gemspec
+++ b/web_translate_it.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'web_translate_it'
-  s.version     = '3.2.0'
+  s.version     = '3.2.1'
   s.required_ruby_version = '>= 3.0'
   s.summary     = 'A CLI tool to sync locale files with WebTranslateIt.com.'
   s.description = 'A Command Line Interface tool to push and pull language files to WebTranslateIt.com.'


### PR DESCRIPTION
Replace @@api_key, @@http_connection, and @@debug class variables with instance variables. Connection now yields self instead of @@http_connection, making it a proper object passed explicitly through the call graph.

- Connection: attr_reader :api_key, :http_connection; yield self
- Term/String: accept connection: keyword in initialize, connection as first positional arg in find_all/find class methods
- Translation/TermTranslation: attr_accessor :connection for save/create/update
- Project: create_locale/delete_locale take connection as first param
- CommandLine: all blocks receive conn, use conn.http_connection
- Debug flag kept as class-level instance variable (@debug via class << self)