### PR TITLE
Extract duplicated retry logic into Util.with_retries (#402)

### DIFF
--- a/lib/web_translate_it/project.rb
+++ b/lib/web_translate_it/project.rb
@@ -4,10 +4,8 @@ module WebTranslateIt
 
   class Project
 
-    def self.fetch_info(api_key) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      success = true
-      tries ||= 3
-      begin
+    def self.fetch_info(api_key) # rubocop:todo Metrics/MethodLength
+      Util.with_retries do
         WebTranslateIt::Connection.new(api_key) do |conn|
           request = Net::HTTP::Get.new("/api/projects/#{api_key}")
           WebTranslateIt::Util.add_fields(request)
@@ -18,79 +16,37 @@ module WebTranslateIt
           puts StringUtil.failure(response.body)
           exit 1
         end
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
-      rescue StandardError
-        puts $ERROR_INFO.inspect
       end
-      success
+    rescue StandardError
+      puts $ERROR_INFO.inspect
     end
 
-    def self.fetch_stats(api_key, file_id = nil) # rubocop:todo Metrics/MethodLength
+    def self.fetch_stats(api_key, file_id = nil)
       url = file_id.nil? ? "/api/projects/#{api_key}/stats" : "/api/projects/#{api_key}/stats?file=#{file_id}"
-      success = true
-      tries ||= 3
-      begin
+      Util.with_retries do
         WebTranslateIt::Connection.new(api_key) do |conn|
           request = Net::HTTP::Get.new(url)
           WebTranslateIt::Util.add_fields(request)
           return Util.handle_response(conn.http_connection.request(request), true)
         end
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
-    def self.create_locale(connection, locale_code) # rubocop:todo Metrics/MethodLength
-      success = true
-      tries ||= 3
-      begin
+    def self.create_locale(connection, locale_code)
+      Util.with_retries do
         request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/locales")
         WebTranslateIt::Util.add_fields(request)
         request.set_form_data({'id' => locale_code}, ';')
         Util.handle_response(connection.http_connection.request(request), true)
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
-    def self.delete_locale(connection, locale_code) # rubocop:todo Metrics/MethodLength
-      success = true
-      tries ||= 3
-      begin
+    def self.delete_locale(connection, locale_code)
+      Util.with_retries do
         request = Net::HTTP::Delete.new("/api/projects/#{connection.api_key}/locales/#{locale_code}")
         WebTranslateIt::Util.add_fields(request)
         Util.handle_response(connection.http_connection.request(request), true)
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
   end

--- a/lib/web_translate_it/string.rb
+++ b/lib/web_translate_it/string.rb
@@ -52,16 +52,14 @@ module WebTranslateIt
     #
     # to find and instantiate an array of String which key is like `product_name_123`.
 
-    def self.find_all(connection, params = {}) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-      success = true
-      tries ||= 3
+    def self.find_all(connection, params = {}) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       params.stringify_keys!
       url = "/api/projects/#{connection.api_key}/strings"
       url += "?#{HashUtil.to_params('filters' => params)}" unless params.empty?
 
       request = Net::HTTP::Get.new(url)
       WebTranslateIt::Util.add_fields(request)
-      begin
+      Util.with_retries do
         strings = []
         while request
           response = connection.http_connection.request(request)
@@ -81,16 +79,7 @@ module WebTranslateIt
           end
         end
         return strings
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     # Find a String based on its ID
@@ -107,28 +96,17 @@ module WebTranslateIt
     # to find and instantiate the String which ID is `1234`.
     #
 
-    def self.find(connection, id) # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
-      success = true
-      tries ||= 3
+    def self.find(connection, id)
       request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/strings/#{id}")
       WebTranslateIt::Util.add_fields(request)
-      begin
+      Util.with_retries do
         response = connection.http_connection.request(request)
         return nil if response.code.to_i == 404
 
         string = WebTranslateIt::String.new(JSON.parse(response.body), connection: connection)
         string.new_record = false
         return string
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     # Update or create a String to WebTranslateIt.com
@@ -156,23 +134,12 @@ module WebTranslateIt
     #   end
     #
 
-    def delete # rubocop:todo Metrics/MethodLength
-      success = true
-      tries ||= 3
+    def delete
       request = Net::HTTP::Delete.new("/api/projects/#{connection.api_key}/strings/#{id}")
       WebTranslateIt::Util.add_fields(request)
-      begin
+      Util.with_retries do
         Util.handle_response(connection.http_connection.request(request), true, true)
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     # Gets a Translation for a String
@@ -185,16 +152,14 @@ module WebTranslateIt
     #   end
     #
 
-    def translation_for(locale) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-      success = true
-      tries ||= 3
+    def translation_for(locale) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       translation = translations.detect { |t| t.locale == locale }
       return translation if translation
       return nil if new_record
 
       request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/strings/#{id}/locales/#{locale}/translations")
       WebTranslateIt::Util.add_fields(request)
-      begin
+      Util.with_retries do
         response = Util.handle_response(connection.http_connection.request(request), true, true)
         hash = JSON.parse(response)
         return nil if hash.empty?
@@ -202,16 +167,7 @@ module WebTranslateIt
         translation = WebTranslateIt::Translation.new(hash)
         translation.connection = connection
         return translation
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     protected
@@ -220,8 +176,6 @@ module WebTranslateIt
     #
 
     def update # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      success = true
-      tries ||= 3
       request = Net::HTTP::Put.new("/api/projects/#{connection.api_key}/strings/#{id}")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
@@ -232,44 +186,24 @@ module WebTranslateIt
         translation.save
       end
 
-      begin
+      Util.with_retries do
         Util.handle_response(connection.http_connection.request(request), true, true)
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     # Create a new String to WebTranslateIt.com
     #
 
-    def create # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      success = true
-      tries ||= 3
+    def create
       request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/strings")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json(true)
-      begin
+      Util.with_retries do
         response = JSON.parse(Util.handle_response(connection.http_connection.request(request), true, true))
         self.id = response['id']
         self.new_record = false
         return true
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     def to_json(with_translations = false) # rubocop:todo Metrics/AbcSize

--- a/lib/web_translate_it/term.rb
+++ b/lib/web_translate_it/term.rb
@@ -42,16 +42,14 @@ module WebTranslateIt
     #
     #  puts terms.inspect #=> An array of WebTranslateIt::Term objects
 
-    def self.find_all(connection, params = {}) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-      success = true
-      tries ||= 3
+    def self.find_all(connection, params = {}) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       params.stringify_keys!
       url = "/api/projects/#{connection.api_key}/terms"
       url += "?#{HashUtil.to_params(params)}" unless params.empty?
 
       request = Net::HTTP::Get.new(url)
       WebTranslateIt::Util.add_fields(request)
-      begin
+      Util.with_retries do
         terms = []
         while request
           response = connection.http_connection.request(request)
@@ -71,16 +69,7 @@ module WebTranslateIt
           end
         end
         return terms
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     # Find a Term based on its ID
@@ -97,28 +86,17 @@ module WebTranslateIt
     # to find and instantiate the Term which ID is `1234`.
     #
 
-    def self.find(connection, term_id) # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
-      success = true
-      tries ||= 3
+    def self.find(connection, term_id)
       request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/terms/#{term_id}")
       WebTranslateIt::Util.add_fields(request)
-      begin
+      Util.with_retries do
         response = connection.http_connection.request(request)
         return nil if response.code.to_i == 404
 
         term = WebTranslateIt::Term.new(JSON.parse(response.body), connection: connection)
         term.new_record = false
         return term
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     # Update or create a Term to WebTranslateIt.com
@@ -146,23 +124,12 @@ module WebTranslateIt
     #   end
     #
 
-    def delete # rubocop:todo Metrics/MethodLength
-      success = true
-      tries ||= 3
+    def delete
       request = Net::HTTP::Delete.new("/api/projects/#{connection.api_key}/terms/#{id}")
       WebTranslateIt::Util.add_fields(request)
-      begin
+      Util.with_retries do
         Util.handle_response(connection.http_connection.request(request), true, true)
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     # Gets a Translation for a Term
@@ -175,16 +142,14 @@ module WebTranslateIt
     #   end
     #
 
-    def translation_for(locale) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-      success = true
-      tries ||= 3
+    def translation_for(locale) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       translation = translations.detect { |t| t.locale == locale }
       return translation if translation
       return nil if new_record
 
       request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/terms/#{id}/locales/#{locale}/translations")
       WebTranslateIt::Util.add_fields(request)
-      begin
+      Util.with_retries do
         response = Util.handle_response(connection.http_connection.request(request), true, true)
         array = JSON.parse(response)
         return nil if array.empty?
@@ -195,23 +160,12 @@ module WebTranslateIt
           translations.push(term_translation)
         end
         return translations
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     protected
 
     def update # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      success = true
-      tries ||= 3
       request = Net::HTTP::Put.new("/api/projects/#{connection.api_key}/terms/#{id}")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
@@ -222,42 +176,22 @@ module WebTranslateIt
         translation.save
       end
 
-      begin
+      Util.with_retries do
         Util.handle_response(connection.http_connection.request(request), true, true)
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
-    def create # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      success = true
-      tries ||= 3
+    def create
       request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/terms")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json(true)
 
-      begin
+      Util.with_retries do
         response = JSON.parse(Util.handle_response(connection.http_connection.request(request), true, true))
         self.id = response['id']
         self.new_record = false
         return true
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
     def to_json(with_translations = false)

--- a/lib/web_translate_it/term_translation.rb
+++ b/lib/web_translate_it/term_translation.rb
@@ -56,48 +56,26 @@ module WebTranslateIt
 
     protected
 
-    def create # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      success = true
-      tries ||= 3
+    def create # rubocop:todo Metrics/AbcSize
       request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/terms/#{term_id}/locales/#{locale}/translations")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
 
-      begin
+      Util.with_retries do
         response = JSON.parse(Util.handle_response(connection.http_connection.request(request), true, true))
         self.id = response['id']
         self.new_record = false
         return true
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
-    def update # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      success = true
-      tries ||= 3
+    def update
       request = Net::HTTP::Put.new("/api/projects/#{connection.api_key}/terms/#{id}/locales/#{locale}/translations/#{id}")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
-      begin
+      Util.with_retries do
         Util.handle_response(connection.http_connection.request(request), true, true)
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        else
-          success = false
-        end
       end
-      success
     end
 
   end

--- a/lib/web_translate_it/translation.rb
+++ b/lib/web_translate_it/translation.rb
@@ -37,19 +37,12 @@ module WebTranslateIt
     #   end
     #
 
-    def save # rubocop:todo Metrics/MethodLength
-      tries ||= 3
+    def save
       request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/strings/#{string_id}/locales/#{locale}/translations")
       WebTranslateIt::Util.add_fields(request)
       request.body = to_json
-      begin
+      Util.with_retries do
         Util.handle_response(connection.http_connection.request(request), true, true)
-      rescue Timeout::Error
-        puts 'Request timeout. Will retry in 5 seconds.'
-        if (tries -= 1).positive?
-          sleep(5)
-          retry
-        end
       end
     end
 

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -37,7 +37,6 @@ module WebTranslateIt
     #
     def fetch(http_connection, force = false) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
       success = true
-      tries ||= 3
       display = []
       if fresh
         display.push(file_path)
@@ -51,17 +50,13 @@ module WebTranslateIt
         WebTranslateIt::Util.add_fields(request)
         FileUtils.mkpath(file_path.split('/')[0..-2].join('/')) unless File.exist?(file_path) || (file_path.split('/')[0..-2].join('/') == '')
         begin
-          response = http_connection.request(request)
-          File.open(file_path, 'wb') { |file| file << response.body } if response.code.to_i == 200
-          display.push Util.handle_response(response)
-        rescue Timeout::Error
-          puts StringUtil.failure('Request timeout. Will retry in 5 seconds.')
-          if (tries -= 1).positive?
-            sleep(5)
-            retry
-          else
-            success = false
+          result = Util.with_retries do
+            response = http_connection.request(request)
+            File.open(file_path, 'wb') { |file| file << response.body } if response.code.to_i == 200
+            display.push Util.handle_response(response)
+            true
           end
+          success = false if result == false
         rescue StandardError
           display.push StringUtil.failure("An error occured: #{$ERROR_INFO}")
           success = false
@@ -96,9 +91,8 @@ module WebTranslateIt
     # rubocop:todo Metrics/ParameterLists
     # rubocop:todo Metrics/MethodLength
     # rubocop:todo Metrics/AbcSize
-    def upload(http_connection, merge = false, ignore_missing = false, label = nil, minor_changes = false, force = false, rename_others = false, destination_path = nil) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/ParameterLists, Metrics/PerceivedComplexity
+    def upload(http_connection, merge = false, ignore_missing = false, label = nil, minor_changes = false, force = false, rename_others = false, destination_path = nil) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength, Metrics/ParameterLists, Metrics/PerceivedComplexity
       success = true
-      tries ||= 3
       display = []
       display.push(file_path)
       display.push "#{StringUtil.checksumify(local_checksum.to_s)}..#{StringUtil.checksumify(remote_checksum.to_s)}"
@@ -117,15 +111,11 @@ module WebTranslateIt
             request = Net::HTTP::Put.new(api_url)
             WebTranslateIt::Util.add_fields(request)
             request.set_form params, 'multipart/form-data'
-            display.push Util.handle_response(http_connection.request(request))
-          rescue Timeout::Error
-            puts StringUtil.failure('Request timeout. Will retry in 5 seconds.')
-            if (tries -= 1).positive? # rubocop:todo Metrics/BlockNesting
-              sleep(5)
-              retry
-            else
-              success = false
+            result = Util.with_retries do
+              display.push Util.handle_response(http_connection.request(request))
+              true
             end
+            success = false if result == false
           rescue StandardError
             display.push StringUtil.failure("An error occured: #{$ERROR_INFO}")
             success = false
@@ -157,7 +147,6 @@ module WebTranslateIt
     #
     def create(http_connection) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
-      tries ||= 3
       display = []
       display.push file_path
       display.push "#{StringUtil.checksumify(local_checksum.to_s)}..[     ]"
@@ -168,16 +157,12 @@ module WebTranslateIt
           request = Net::HTTP::Post.new(api_url_for_create)
           WebTranslateIt::Util.add_fields(request)
           request.set_form params, 'multipart/form-data'
-          display.push Util.handle_response(http_connection.request(request))
-          puts StringUtil.array_to_columns(display)
-        rescue Timeout::Error
-          puts StringUtil.failure('Request timeout. Will retry in 5 seconds.')
-          if (tries -= 1).positive?
-            sleep(5)
-            retry
-          else
-            success = false
+          result = Util.with_retries do
+            display.push Util.handle_response(http_connection.request(request))
+            puts StringUtil.array_to_columns(display)
+            true
           end
+          success = false if result == false
         rescue StandardError
           display.push StringUtil.failure("An error occured: #{$ERROR_INFO}")
           success = false
@@ -192,23 +177,18 @@ module WebTranslateIt
     #
     def delete(http_connection) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
-      tries ||= 3
       display = []
       display.push file_path
       if File.exist?(file_path)
         begin
           request = Net::HTTP::Delete.new(api_url_for_delete)
           WebTranslateIt::Util.add_fields(request)
-          display.push Util.handle_response(http_connection.request(request))
-          puts StringUtil.array_to_columns(display)
-        rescue Timeout::Error
-          puts StringUtil.failure('Request timeout. Will retry in 5 seconds.')
-          if (tries -= 1).positive?
-            sleep(5)
-            retry
-          else
-            success = false
+          result = Util.with_retries do
+            display.push Util.handle_response(http_connection.request(request))
+            puts StringUtil.array_to_columns(display)
+            true
           end
+          success = false if result == false
         rescue StandardError
           display.push StringUtil.failure("An error occured: #{$ERROR_INFO}")
           success = false

--- a/lib/web_translate_it/util.rb
+++ b/lib/web_translate_it/util.rb
@@ -48,6 +48,19 @@ module WebTranslateIt
       request.add_field('Content-Type', 'application/json')
     end
 
+    # Execute a block with automatic retry on Timeout::Error.
+    # Returns the block's return value on success, or false after retries are exhausted.
+    def self.with_retries(retries: 3, delay: 5)
+      yield
+    rescue Timeout::Error
+      puts 'Request timeout. Will retry in 5 seconds.'
+      if (retries -= 1).positive?
+        sleep(delay)
+        retry
+      end
+      false
+    end
+
     ##
     # Ask a question. Returns a true for yes, false for no, default for nil.
 

--- a/spec/web_translate_it/util_spec.rb
+++ b/spec/web_translate_it/util_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe WebTranslateIt::Util do
+  describe '.with_retries' do
+    it 'returns the block value on success' do
+      result = described_class.with_retries(retries: 3, delay: 0) { 42 }
+      expect(result).to eq 42
+    end
+
+    it 'retries on Timeout::Error and succeeds' do
+      attempts = 0
+      result = described_class.with_retries(retries: 3, delay: 0) do
+        attempts += 1
+        raise Timeout::Error if attempts < 3
+
+        'ok'
+      end
+      expect(result).to eq 'ok'
+      expect(attempts).to eq 3
+    end
+
+    it 'returns false after exhausting retries' do
+      attempts = 0
+      result = described_class.with_retries(retries: 2, delay: 0) do
+        attempts += 1
+        raise Timeout::Error
+      end
+      expect(result).to be false
+      expect(attempts).to eq 2
+    end
+
+    it 'does not catch non-timeout errors' do
+      expect do
+        described_class.with_retries(retries: 3, delay: 0) { raise StandardError, 'boom' }
+      end.to raise_error(StandardError, 'boom')
+    end
+
+    it 'prints a timeout message on each retry' do
+      expect do
+        described_class.with_retries(retries: 2, delay: 0) { raise Timeout::Error }
+      end.to output("Request timeout. Will retry in 5 seconds.\n" * 2).to_stdout
+    end
+
+    it 'defaults to 3 retries' do
+      attempts = 0
+      described_class.with_retries(delay: 0) do
+        attempts += 1
+        raise Timeout::Error
+      end
+      expect(attempts).to eq 3
+    end
+  end
+end


### PR DESCRIPTION
Replace 23 hand-rolled `tries ||= 3 / rescue Timeout::Error / sleep(5) / retry` blocks across 6 classes with a single `Util.with_retries` helper.

The helper yields the given block, catches Timeout::Error, prints a message, sleeps, and retries up to the configured number of times (default 3). Returns the block's value on success, or false when retries are exhausted.

Files changed:
- lib/web_translate_it/util.rb          — add with_retries method
- lib/web_translate_it/string.rb        — 6 methods updated
- lib/web_translate_it/term.rb          — 6 methods updated
- lib/web_translate_it/term_translation.rb — 2 methods updated
- lib/web_translate_it/translation.rb   — 1 method updated
- lib/web_translate_it/project.rb       — 4 methods updated
- lib/web_translate_it/translation_file.rb — 4 methods updated
- spec/web_translate_it/util_spec.rb    — new: 6 examples for with_retries

Several methods dropped rubocop Metrics/ suppressions that are no longer needed now that the retry boilerplate is gone.