### PR TITLE
Stop swallowing exceptions in rescue StandardError (#406)

### DIFF
--- a/lib/web_translate_it/connection.rb
+++ b/lib/web_translate_it/connection.rb
@@ -33,13 +33,14 @@ module WebTranslateIt
       begin
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
         @http_connection = http.start
-        yield self if block_given?
       rescue OpenSSL::SSL::SSLError
         puts 'Error: Unable to verify SSL certificate.'
         exit 1
-      rescue StandardError
-        puts $ERROR_INFO
+      rescue StandardError => e
+        puts e.message
+        raise
       end
+      yield self if block_given?
     end
 
     def self.turn_debug_on

--- a/lib/web_translate_it/project.rb
+++ b/lib/web_translate_it/project.rb
@@ -17,8 +17,9 @@ module WebTranslateIt
           exit 1
         end
       end
-    rescue StandardError
-      puts $ERROR_INFO.inspect
+    rescue StandardError => e
+      puts e.inspect
+      raise
     end
 
     def self.fetch_stats(api_key, file_id = nil)

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -57,8 +57,8 @@ module WebTranslateIt
             true
           end
           success = false if result == false
-        rescue StandardError
-          display.push StringUtil.failure("An error occured: #{$ERROR_INFO}")
+        rescue StandardError => e
+          display.push StringUtil.failure("An error occured: #{e.message}")
           success = false
         end
 
@@ -116,8 +116,8 @@ module WebTranslateIt
               true
             end
             success = false if result == false
-          rescue StandardError
-            display.push StringUtil.failure("An error occured: #{$ERROR_INFO}")
+          rescue StandardError => e
+            display.push StringUtil.failure("An error occured: #{e.message}")
             success = false
           end
         else
@@ -163,8 +163,8 @@ module WebTranslateIt
             true
           end
           success = false if result == false
-        rescue StandardError
-          display.push StringUtil.failure("An error occured: #{$ERROR_INFO}")
+        rescue StandardError => e
+          display.push StringUtil.failure("An error occured: #{e.message}")
           success = false
         end
       else
@@ -189,8 +189,8 @@ module WebTranslateIt
             true
           end
           success = false if result == false
-        rescue StandardError
-          display.push StringUtil.failure("An error occured: #{$ERROR_INFO}")
+        rescue StandardError => e
+          display.push StringUtil.failure("An error occured: #{e.message}")
           success = false
         end
       else
@@ -229,7 +229,7 @@ module WebTranslateIt
 
     def local_checksum
       Digest::SHA1.hexdigest(File.read(file_path))
-    rescue StandardError
+    rescue StandardError => _e
       ''
     end
 


### PR DESCRIPTION
- connection.rb: Move `yield self` outside begin/rescue so caller errors propagate naturally. Log and re-raise on startup failure instead of silently swallowing.
- project.rb: Log and re-raise in fetch_info instead of swallowing.
- translation_file.rb: Replace deprecated $ERROR_INFO global with proper `rescue StandardError => e` in all 5 rescue blocks.