### PR TITLE
Replace fragile path splitting with File.dirname (#408)

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,5 +1,6 @@
 ## Edge (unreleased)
 
+* Replace fragile path splitting with `File.dirname` in `TranslationFile#fetch`. Add specs. #408
 * Decompose `CommandLine` god class into 11 focused command classes under `Commands::` namespace, rename to `Runner`. #404
 * Extract `ApiResource` base class from `String` and `Term` to remove duplicated CRUD logic. #403
 * Fix generic `rescue` blocks to capture and re-raise `StandardError`. #406

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -48,7 +48,8 @@ module WebTranslateIt
 
         request = Net::HTTP::Get.new(api_url)
         WebTranslateIt::Util.add_fields(request)
-        FileUtils.mkpath(file_path.split('/')[0..-2].join('/')) unless File.exist?(file_path) || (file_path.split('/')[0..-2].join('/') == '')
+        dir = File.dirname(file_path)
+        FileUtils.mkpath(dir) unless File.exist?(file_path) || dir == '.'
         begin
           result = Util.with_retries do
             response = http_connection.request(request)

--- a/spec/web_translate_it/translation_file_spec.rb
+++ b/spec/web_translate_it/translation_file_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe WebTranslateIt::TranslationFile do
+  let(:api_key) { 'test_api_key' }
+  let(:http_connection) { instance_double(Net::HTTP) }
+  let(:ok_response) do
+    instance_double(Net::HTTPSuccess, code: '200', body: 'file content', :[] => nil)
+  end
+
+  before do
+    allow(http_connection).to receive(:request).and_return(ok_response)
+  end
+
+  describe '#fetch' do
+    context 'when file_path has nested directories' do
+      let(:file) { described_class.new(1, 'config/locales/app/en.yml', 'en', api_key) }
+
+      it 'creates intermediate directories with FileUtils.mkpath' do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with('config/locales/app/en.yml').and_return(false)
+        allow(File).to receive(:open).with('config/locales/app/en.yml', 'wb').and_yield(StringIO.new)
+        allow(FileUtils).to receive(:mkpath)
+
+        file.fetch(http_connection, true)
+
+        expect(FileUtils).to have_received(:mkpath).with('config/locales/app')
+      end
+    end
+
+    context 'when file_path is a bare filename (no directory)' do
+      let(:file) { described_class.new(1, 'en.yml', 'en', api_key) }
+
+      it 'does not call mkpath' do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with('en.yml').and_return(false)
+        allow(File).to receive(:open).with('en.yml', 'wb').and_yield(StringIO.new)
+        allow(FileUtils).to receive(:mkpath)
+
+        file.fetch(http_connection, true)
+
+        expect(FileUtils).not_to have_received(:mkpath)
+      end
+    end
+
+    context 'when file already exists locally' do
+      let(:file) { described_class.new(1, 'config/locales/en.yml', 'en', api_key) }
+
+      it 'does not call mkpath' do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with('config/locales/en.yml').and_return(true)
+        allow(File).to receive(:open).with('config/locales/en.yml', 'wb').and_yield(StringIO.new)
+        allow(FileUtils).to receive(:mkpath)
+
+        file.fetch(http_connection, true)
+
+        expect(FileUtils).not_to have_received(:mkpath)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Use File.dirname instead of file_path.split('/')[0..-2].join('/') in TranslationFile#fetch
- Add translation_file_spec.rb with 3 examples covering nested paths, bare filenames, and existing files