### PR TITLE
Refactor long parameter lists to use keyword arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Metrics/BlockLength:
     - 'spec/**/*_spec.rb'
     - '*.gemspec'
 
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+
 # - RSpec Cops --------------------------------------------------------------------------------------------------------
 # N.B. In some future version of ruboco-rspec IgnoredMetadata can be used instead of Exclude
 

--- a/bin/wti
+++ b/bin/wti
@@ -28,7 +28,7 @@ show_commands = <<~COMMANDS
 COMMANDS
 
 SUB_COMMANDS = %w[pull push match diff add rm mv addlocale rmlocale status st init].freeze
-global_options = Optimist.options do
+Optimist.options do
   stop_on SUB_COMMANDS
   banner show_commands
   version "wti version #{WebTranslateIt::Util.version}"
@@ -135,7 +135,7 @@ end
 
 begin
   WebTranslateIt::Connection.turn_debug_on if command_options.debug
-  WebTranslateIt::Runner.new(command, command_options, global_options, ARGV, File.expand_path('.'))
+  WebTranslateIt::Runner.new(command, command_options, ARGV, File.expand_path('.'))
 rescue Interrupt
   puts StringUtil.failure("\nQuitting...")
   exit 1

--- a/lib/web_translate_it/commands/mv.rb
+++ b/lib/web_translate_it/commands/mv.rb
@@ -29,7 +29,7 @@ module WebTranslateIt
 
         complete_success = true
         configuration.files.find_all { |file| file.file_path == source }.each do |master_file|
-          master_file.upload(conn.http_connection, false, false, nil, false, true, true, destination)
+          master_file.upload(conn.http_connection, force: true, rename_others: true, destination_path: destination)
           if File.exist?(source)
             File.rename(source, destination)
             puts StringUtil.success("Moved master file #{master_file.file_path}.")

--- a/lib/web_translate_it/commands/push.rb
+++ b/lib/web_translate_it/commands/push.rb
@@ -22,7 +22,7 @@ module WebTranslateIt
               puts "Couldn't find any local files registered on WebTranslateIt to push."
             else
               files.each do |file|
-                success = file.upload(conn.http_connection, command_options[:merge], command_options.ignore_missing, command_options.label, command_options[:minor], command_options.force)
+                success = file.upload(conn.http_connection, merge: command_options[:merge], ignore_missing: command_options.ignore_missing, label: command_options.label, minor_changes: command_options[:minor], force: command_options.force)
                 complete_success = false unless success
               end
             end

--- a/lib/web_translate_it/configuration.rb
+++ b/lib/web_translate_it/configuration.rb
@@ -72,7 +72,7 @@ module WebTranslateIt
         elsif ignore_files&.any? { |glob| File.fnmatch(glob, project_file['name']) }
           puts "Ignoring #{project_file['name']}"
         else
-          array_files.push TranslationFile.new(project_file['id'], project_file['name'], project_file['locale_code'], api_key, project_file['updated_at'], project_file['hash_file'], project_file['master_project_file_id'], project_file['fresh'])
+          array_files.push TranslationFile.from_api(project_file, api_key)
         end
       end
       array_files

--- a/lib/web_translate_it/runner.rb
+++ b/lib/web_translate_it/runner.rb
@@ -31,7 +31,7 @@ module WebTranslateIt
 
     attr_accessor :configuration, :command_options, :parameters
 
-    def initialize(command, command_options, _global_options, parameters, project_path) # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
+    def initialize(command, command_options, parameters, project_path) # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
       self.command_options = command_options
       self.parameters = parameters
       unless command == 'init'

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -12,7 +12,20 @@ module WebTranslateIt
 
     attr_accessor :id, :file_path, :locale, :api_key, :updated_at, :remote_checksum, :master_id, :fresh
 
-    def initialize(id, file_path, locale, api_key, updated_at = nil, remote_checksum = '', master_id = nil, fresh = nil) # rubocop:todo Metrics/ParameterLists
+    def self.from_api(project_file, api_key)
+      new(
+        project_file['id'],
+        project_file['name'],
+        project_file['locale_code'],
+        api_key,
+        updated_at: project_file['updated_at'],
+        remote_checksum: project_file['hash_file'],
+        master_id: project_file['master_project_file_id'],
+        fresh: project_file['fresh']
+      )
+    end
+
+    def initialize(id, file_path, locale, api_key, updated_at: nil, remote_checksum: '', master_id: nil, fresh: nil)
       self.id         = id
       self.file_path  = file_path
       self.locale     = locale
@@ -89,10 +102,9 @@ module WebTranslateIt
     # Note that the request might or might not eventually be acted upon, as it might be disallowed when processing
     # actually takes place. This is due to the fact that language file imports are handled by background processing.
     # rubocop:todo Metrics/PerceivedComplexity
-    # rubocop:todo Metrics/ParameterLists
     # rubocop:todo Metrics/MethodLength
     # rubocop:todo Metrics/AbcSize
-    def upload(http_connection, merge = false, ignore_missing = false, label = nil, minor_changes = false, force = false, rename_others = false, destination_path = nil) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength, Metrics/ParameterLists, Metrics/PerceivedComplexity
+    def upload(http_connection, merge: false, ignore_missing: false, label: nil, minor_changes: false, force: false, rename_others: false, destination_path: nil) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
       success = true
       display = []
       display.push(file_path)
@@ -132,7 +144,6 @@ module WebTranslateIt
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/ParameterLists
     # rubocop:enable Metrics/PerceivedComplexity
 
     # Create a master language file to Web Translate It by performing a POST Request.
@@ -141,7 +152,7 @@ module WebTranslateIt
     #
     #   configuration = WebTranslateIt::Configuration.new
     #   file = TranslationFile.new(nil, file_path, nil, configuration.api_key)
-    #   file.create # should respond the HTTP code 201 Created
+    #   file.create(http_connection) # should respond the HTTP code 201 Created
     #
     # Note that the request might or might not eventually be acted upon, as it might be disallowed when processing
     # actually takes place. This is due to the fact that language file imports are handled by background processing.


### PR DESCRIPTION
- Convert TranslationFile#upload from positional to keyword arguments, making call sites self-documenting.
- Extract TranslationFile.from_api factory method to encapsulate the API hash-to-object mapping, simplifying configuration.rb.
- Convert TranslationFile#initialize optional params to keyword args.
- Remove unused _global_options parameter from Runner#initialize.
- Configure rubocop CountKeywordArgs: false for ParameterLists cop.

Fixes #405