### PR TITLE
Separate display logic from TranslationFile business methods

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,5 +1,7 @@
 ## Edge (unreleased)
 
+* Separate display logic from business methods in `TranslationFile`. `fetch`, `upload`, `create`, and `delete` now return a `Result` struct instead of printing to stdout, enabling programmatic use without terminal side-effects. Remove broken `modified_remotely?` dead code. #407
+* Refactor long parameter lists to use keyword arguments in `TranslationFile#upload` and `TranslationFile#initialize`. Extract `TranslationFile.from_api` factory method. Remove unused `_global_options` parameter from `Runner#initialize`. #405
 * Replace fragile path splitting with `File.dirname` in `TranslationFile#fetch`. Add specs. #408
 * Decompose `CommandLine` god class into 11 focused command classes under `Commands::` namespace, rename to `Runner`. #404
 * Extract `ApiResource` base class from `String` and `Term` to remove duplicated CRUD logic. #403

--- a/lib/web_translate_it/commands/add.rb
+++ b/lib/web_translate_it/commands/add.rb
@@ -20,8 +20,9 @@ module WebTranslateIt
           if to_add.any?
             to_add.each do |param|
               file = TranslationFile.new(nil, param.gsub(/ /, '\\ '), nil, configuration.api_key)
-              success = file.create(conn.http_connection)
-              complete_success = false unless success
+              result = file.create(conn.http_connection)
+              puts StringUtil.array_to_columns(result.output)
+              complete_success = false unless result.success
             end
           else
             puts 'No new master file to add.'

--- a/lib/web_translate_it/commands/mv.rb
+++ b/lib/web_translate_it/commands/mv.rb
@@ -29,7 +29,8 @@ module WebTranslateIt
 
         complete_success = true
         configuration.files.find_all { |file| file.file_path == source }.each do |master_file|
-          master_file.upload(conn.http_connection, force: true, rename_others: true, destination_path: destination)
+          result = master_file.upload(conn.http_connection, force: true, rename_others: true, destination_path: destination)
+          puts StringUtil.array_to_columns(result.output)
           if File.exist?(source)
             File.rename(source, destination)
             puts StringUtil.success("Moved master file #{master_file.file_path}.")
@@ -42,8 +43,9 @@ module WebTranslateIt
           end
           configuration.reload
           configuration.files.find_all { |file| file.master_id == master_file.id }.each do |target_file|
-            success = target_file.fetch(conn.http_connection)
-            complete_success = false unless success
+            result = target_file.fetch(conn.http_connection)
+            print StringUtil.array_to_columns(result.output)
+            complete_success = false unless result.success
           end
           puts StringUtil.success('All done.') if complete_success
         end

--- a/lib/web_translate_it/commands/pull.rb
+++ b/lib/web_translate_it/commands/pull.rb
@@ -46,8 +46,9 @@ module WebTranslateIt
           threads << Thread.new(file_array) do |f_array|
             with_connection do |conn|
               f_array.each do |file|
-                success = file.fetch(conn.http_connection, command_options.force)
-                complete_success = false unless success
+                result = file.fetch(conn.http_connection, command_options.force)
+                print StringUtil.array_to_columns(result.output)
+                complete_success = false unless result.success
               end
             end
           end

--- a/lib/web_translate_it/commands/push.rb
+++ b/lib/web_translate_it/commands/push.rb
@@ -22,8 +22,9 @@ module WebTranslateIt
               puts "Couldn't find any local files registered on WebTranslateIt to push."
             else
               files.each do |file|
-                success = file.upload(conn.http_connection, merge: command_options[:merge], ignore_missing: command_options.ignore_missing, label: command_options.label, minor_changes: command_options[:minor], force: command_options.force)
-                complete_success = false unless success
+                result = file.upload(conn.http_connection, merge: command_options[:merge], ignore_missing: command_options.ignore_missing, label: command_options.label, minor_changes: command_options[:minor], force: command_options.force)
+                puts StringUtil.array_to_columns(result.output)
+                complete_success = false unless result.success
               end
             end
           end

--- a/lib/web_translate_it/commands/rm.rb
+++ b/lib/web_translate_it/commands/rm.rb
@@ -35,7 +35,8 @@ module WebTranslateIt
 
         complete_success = true
         files.each do |master_file|
-          master_file.delete(conn.http_connection)
+          result = master_file.delete(conn.http_connection)
+          puts StringUtil.array_to_columns(result.output)
           if File.exist?(master_file.file_path)
             File.delete(master_file.file_path)
             puts StringUtil.success("Deleted master file #{master_file.file_path}.")

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -12,6 +12,8 @@ module WebTranslateIt
 
     attr_accessor :id, :file_path, :locale, :api_key, :updated_at, :remote_checksum, :master_id, :fresh
 
+    Result = Struct.new(:success, :output)
+
     def self.from_api(project_file, api_key)
       new(
         project_file['id'],
@@ -79,8 +81,7 @@ module WebTranslateIt
       else
         display.push StringUtil.success('Skipped')
       end
-      print StringUtil.array_to_columns(display)
-      success
+      Result.new(success, display)
     end
 
     def fetch_remote_content(http_connection)
@@ -136,11 +137,10 @@ module WebTranslateIt
         else
           display.push StringUtil.success('Skipped')
         end
-        puts StringUtil.array_to_columns(display)
       else
-        puts StringUtil.failure("Can't push #{file_path}. File doesn't exist locally.")
+        display.push StringUtil.failure("Can't push #{file_path}. File doesn't exist locally.")
       end
-      success
+      Result.new(success, display)
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
@@ -171,7 +171,6 @@ module WebTranslateIt
           request.set_form params, 'multipart/form-data'
           result = Util.with_retries do
             display.push Util.handle_response(http_connection.request(request))
-            puts StringUtil.array_to_columns(display)
             true
           end
           success = false if result == false
@@ -180,9 +179,9 @@ module WebTranslateIt
           success = false
         end
       else
-        puts StringUtil.failure("\nFile #{file_path} doesn't exist locally!")
+        display.push StringUtil.failure("File #{file_path} doesn't exist locally!")
       end
-      success
+      Result.new(success, display)
     end
 
     # Delete a master language file from Web Translate It by performing a DELETE Request.
@@ -197,7 +196,6 @@ module WebTranslateIt
           WebTranslateIt::Util.add_fields(request)
           result = Util.with_retries do
             display.push Util.handle_response(http_connection.request(request))
-            puts StringUtil.array_to_columns(display)
             true
           end
           success = false if result == false
@@ -206,17 +204,13 @@ module WebTranslateIt
           success = false
         end
       else
-        puts StringUtil.failure("\nMaster file #{file_path} doesn't exist locally!")
+        display.push StringUtil.failure("Master file #{file_path} doesn't exist locally!")
       end
-      success
+      Result.new(success, display)
     end
 
     def exists?
       File.exist?(file_path)
-    end
-
-    def modified_remotely?
-      fetch == '200 OK'
     end
 
     protected


### PR DESCRIPTION
TranslationFile#fetch, #upload, #create, and #delete now return a Result struct (success, output) instead of printing directly to stdout. Display formatting is handled by command callers.

This allows programmatic use (e.g. Rack middleware auto-fetch) without terminal side-effects. Also removes broken dead code modified_remotely? and renames Result :display to :output to avoid Struct#display override.

Fixes #407