### PR TITLE
Extract threading logic into Util.concurrent_batch (#409)

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,5 +1,6 @@
 ## Edge (unreleased)
 
+* Extract threading logic into `Util.concurrent_batch`. Simplify `Pull#pull_files` and fix thread-safety bug with shared mutable state. Use `Thread#value` for error propagation. #409
 * Separate display logic from business methods in `TranslationFile`. `fetch`, `upload`, `create`, and `delete` now return a `Result` struct instead of printing to stdout, enabling programmatic use without terminal side-effects. Remove broken `modified_remotely?` dead code. #407
 * Refactor long parameter lists to use keyword arguments in `TranslationFile#upload` and `TranslationFile#initialize`. Extract `TranslationFile.from_api` factory method. Remove unused `_global_options` parameter from `Runner#initialize`. #405
 * Replace fragile path splitting with `File.dirname` in `TranslationFile#fetch`. Add specs. #408

--- a/lib/web_translate_it/commands/pull.rb
+++ b/lib/web_translate_it/commands/pull.rb
@@ -35,28 +35,20 @@ module WebTranslateIt
         files.uniq.sort { |a, b| a.file_path <=> b.file_path }
       end
 
-      def pull_files(files) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-        complete_success = true
+      def pull_files(files) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength, Naming/PredicateMethod
         time = Time.now
-        threads = []
-        n_threads = [(files.size.to_f / 3).ceil, 10].min
-        files.each_slice((files.size.to_f / n_threads).round).each do |file_array|
-          next if file_array.empty?
-
-          threads << Thread.new(file_array) do |f_array|
-            with_connection do |conn|
-              f_array.each do |file|
-                result = file.fetch(conn.http_connection, command_options.force)
-                print StringUtil.array_to_columns(result.output)
-                complete_success = false unless result.success
-              end
+        results, n_threads = Util.concurrent_batch(files) do |batch|
+          with_connection do |conn|
+            batch.map do |file|
+              result = file.fetch(conn.http_connection, command_options.force)
+              print StringUtil.array_to_columns(result.output)
+              result.success
             end
           end
         end
-        threads.each(&:join)
         time = Time.now - time
         puts "Pulled #{files.size} files at #{(files.size / time).round} files/sec, using #{n_threads} threads."
-        complete_success
+        results.all?
       end
 
       def fetch_locales # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity

--- a/lib/web_translate_it/util.rb
+++ b/lib/web_translate_it/util.rb
@@ -61,6 +61,21 @@ module WebTranslateIt
       false
     end
 
+    # Process items in parallel using a thread pool.
+    # Yields each batch (array of items) to the block; collects return values.
+    # Returns [results, n_threads] where results is a flat array of block return values.
+    def self.concurrent_batch(items, batch_size: 3, max_threads: 10, &block)
+      n_threads = [(items.size.to_f / batch_size).ceil, max_threads].min
+      n_threads = 1 if n_threads < 1
+      threads = items.each_slice((items.size.to_f / n_threads).ceil).filter_map do |slice|
+        next if slice.empty?
+
+        Thread.new(slice, &block)
+      end
+      results = threads.flat_map(&:value)
+      [results, n_threads]
+    end
+
     ##
     # Ask a question. Returns a true for yes, false for no, default for nil.
 


### PR DESCRIPTION
- Add Util.concurrent_batch for parallel processing with thread pool
- Use Thread#value for error propagation across threads
- Fix thread-safety bug: derive success from return values instead of shared mutable boolean
- Simplify Pull#pull_files to delegate threading concerns