### PR TITLE
Standardize `to_hash`/`to_json` pattern across all model classes

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,5 +1,6 @@
 ## Edge (unreleased)
 
+* Standardize `to_hash`/`to_json` pattern across all model classes. Make `to_hash` private in `ApiResource`, `String`, and `Term`. Convert positional boolean to keyword argument. #410
 * Extract threading logic into `Util.concurrent_batch`. Simplify `Pull#pull_files` and fix thread-safety bug with shared mutable state. Use `Thread#value` for error propagation. #409
 * Separate display logic from business methods in `TranslationFile`. `fetch`, `upload`, `create`, and `delete` now return a `Result` struct instead of printing to stdout, enabling programmatic use without terminal side-effects. Remove broken `modified_remotely?` dead code. #407
 * Refactor long parameter lists to use keyword arguments in `TranslationFile#upload` and `TranslationFile#initialize`. Extract `TranslationFile.from_api` factory method. Remove unused `_global_options` parameter from `Runner#initialize`. #405

--- a/lib/web_translate_it/api_resource.rb
+++ b/lib/web_translate_it/api_resource.rb
@@ -129,7 +129,7 @@ module WebTranslateIt
     def create # rubocop:todo Metrics/AbcSize
       request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/#{self.class.resource_path}")
       WebTranslateIt::Util.add_fields(request)
-      request.body = to_json(true)
+      request.body = to_json(with_translations: true)
       Util.with_retries do
         response = JSON.parse(Util.handle_response(connection.http_connection.request(request), true, true))
         self.id = response['id']
@@ -138,14 +138,16 @@ module WebTranslateIt
       end
     end
 
-    def to_json_hash
-      {'id' => id}
-    end
-
-    def to_json(with_translations = false) # rubocop:todo Style/OptionalBooleanParameter
-      hash = to_json_hash
+    def to_json(*_args, with_translations: false)
+      hash = to_hash
       hash['translations'] = translations.map(&:to_hash) if translations.any? && with_translations
       MultiJson.dump(hash)
+    end
+
+    private
+
+    def to_hash
+      {'id' => id}
     end
 
   end

--- a/lib/web_translate_it/string.rb
+++ b/lib/web_translate_it/string.rb
@@ -38,7 +38,9 @@ module WebTranslateIt
       translation.string_id = id
     end
 
-    def to_json_hash
+    private
+
+    def to_hash
       {
         'id' => id,
         'key' => key,

--- a/lib/web_translate_it/term.rb
+++ b/lib/web_translate_it/term.rb
@@ -25,7 +25,9 @@ module WebTranslateIt
       translation.term_id = id
     end
 
-    def to_json_hash
+    private
+
+    def to_hash
       {
         'id' => id,
         'text' => text,

--- a/lib/web_translate_it/term_translation.rb
+++ b/lib/web_translate_it/term_translation.rb
@@ -54,6 +54,7 @@ module WebTranslateIt
       MultiJson.dump(to_hash)
     end
 
+
     protected
 
     def create # rubocop:todo Metrics/AbcSize

--- a/lib/web_translate_it/translation.rb
+++ b/lib/web_translate_it/translation.rb
@@ -58,6 +58,7 @@ module WebTranslateIt
       MultiJson.dump(to_hash)
     end
 
+
   end
 
 end


### PR DESCRIPTION
Make `to_hash` private in `ApiResource`, `String`, and `Term`. Convert positional boolean to keyword argument. #410