### PR TITLE
Make with_retries raise on timeout exhaustion (#411)

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,5 +1,6 @@
 ## Edge (unreleased)
 
+* `Util.with_retries` now re-raises `Timeout::Error` after exhausting retries instead of returning `false`. Methods like `find_all`, `find`, `create`, and `update` now return consistent types. #411
 * Standardize `to_hash`/`to_json` pattern across all model classes. Make `to_hash` private in `ApiResource`, `String`, and `Term`. Convert positional boolean to keyword argument. #410
 * Extract threading logic into `Util.concurrent_batch`. Simplify `Pull#pull_files` and fix thread-safety bug with shared mutable state. Use `Thread#value` for error propagation. #409
 * Separate display logic from business methods in `TranslationFile`. `fetch`, `upload`, `create`, and `delete` now return a `Result` struct instead of printing to stdout, enabling programmatic use without terminal side-effects. Remove broken `modified_remotely?` dead code. #407

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -66,13 +66,11 @@ module WebTranslateIt
         dir = File.dirname(file_path)
         FileUtils.mkpath(dir) unless File.exist?(file_path) || dir == '.'
         begin
-          result = Util.with_retries do
+          Util.with_retries do
             response = http_connection.request(request)
             File.open(file_path, 'wb') { |file| file << response.body } if response.code.to_i == 200
             display.push Util.handle_response(response)
-            true
           end
-          success = false if result == false
         rescue StandardError => e
           display.push StringUtil.failure("An error occured: #{e.message}")
           success = false
@@ -102,10 +100,9 @@ module WebTranslateIt
     #
     # Note that the request might or might not eventually be acted upon, as it might be disallowed when processing
     # actually takes place. This is due to the fact that language file imports are handled by background processing.
-    # rubocop:todo Metrics/PerceivedComplexity
     # rubocop:todo Metrics/MethodLength
     # rubocop:todo Metrics/AbcSize
-    def upload(http_connection, merge: false, ignore_missing: false, label: nil, minor_changes: false, force: false, rename_others: false, destination_path: nil) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def upload(http_connection, merge: false, ignore_missing: false, label: nil, minor_changes: false, force: false, rename_others: false, destination_path: nil) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       display = []
       display.push(file_path)
@@ -125,11 +122,9 @@ module WebTranslateIt
             request = Net::HTTP::Put.new(api_url)
             WebTranslateIt::Util.add_fields(request)
             request.set_form params, 'multipart/form-data'
-            result = Util.with_retries do
+            Util.with_retries do
               display.push Util.handle_response(http_connection.request(request))
-              true
             end
-            success = false if result == false
           rescue StandardError => e
             display.push StringUtil.failure("An error occured: #{e.message}")
             success = false
@@ -142,10 +137,9 @@ module WebTranslateIt
       end
       Result.new(success, display)
     end
+
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/PerceivedComplexity
-
     # Create a master language file to Web Translate It by performing a POST Request.
     #
     # Example of implementation:
@@ -169,11 +163,9 @@ module WebTranslateIt
           request = Net::HTTP::Post.new(api_url_for_create)
           WebTranslateIt::Util.add_fields(request)
           request.set_form params, 'multipart/form-data'
-          result = Util.with_retries do
+          Util.with_retries do
             display.push Util.handle_response(http_connection.request(request))
-            true
           end
-          success = false if result == false
         rescue StandardError => e
           display.push StringUtil.failure("An error occured: #{e.message}")
           success = false
@@ -194,11 +186,9 @@ module WebTranslateIt
         begin
           request = Net::HTTP::Delete.new(api_url_for_delete)
           WebTranslateIt::Util.add_fields(request)
-          result = Util.with_retries do
+          Util.with_retries do
             display.push Util.handle_response(http_connection.request(request))
-            true
           end
-          success = false if result == false
         rescue StandardError => e
           display.push StringUtil.failure("An error occured: #{e.message}")
           success = false

--- a/lib/web_translate_it/util.rb
+++ b/lib/web_translate_it/util.rb
@@ -49,7 +49,7 @@ module WebTranslateIt
     end
 
     # Execute a block with automatic retry on Timeout::Error.
-    # Returns the block's return value on success, or false after retries are exhausted.
+    # Returns the block's return value on success, or re-raises after retries are exhausted.
     def self.with_retries(retries: 3, delay: 5)
       yield
     rescue Timeout::Error
@@ -58,7 +58,7 @@ module WebTranslateIt
         sleep(delay)
         retry
       end
-      false
+      raise
     end
 
     # Process items in parallel using a thread pool.

--- a/spec/web_translate_it/util_spec.rb
+++ b/spec/web_translate_it/util_spec.rb
@@ -21,13 +21,14 @@ describe WebTranslateIt::Util do
       expect(attempts).to eq 3
     end
 
-    it 'returns false after exhausting retries' do
+    it 'raises Timeout::Error after exhausting retries' do
       attempts = 0
-      result = described_class.with_retries(retries: 2, delay: 0) do
-        attempts += 1
-        raise Timeout::Error
-      end
-      expect(result).to be false
+      expect do
+        described_class.with_retries(retries: 2, delay: 0) do
+          attempts += 1
+          raise Timeout::Error
+        end
+      end.to raise_error(Timeout::Error)
       expect(attempts).to eq 2
     end
 
@@ -40,14 +41,20 @@ describe WebTranslateIt::Util do
     it 'prints a timeout message on each retry' do
       expect do
         described_class.with_retries(retries: 2, delay: 0) { raise Timeout::Error }
+      rescue Timeout::Error
+        # expected
       end.to output("Request timeout. Will retry in 5 seconds.\n" * 2).to_stdout
     end
 
     it 'defaults to 3 retries' do
       attempts = 0
-      described_class.with_retries(delay: 0) do
-        attempts += 1
-        raise Timeout::Error
+      begin
+        described_class.with_retries(delay: 0) do
+          attempts += 1
+          raise Timeout::Error
+        end
+      rescue Timeout::Error
+        # expected
       end
       expect(attempts).to eq 3
     end


### PR DESCRIPTION
- Re-raise Timeout::Error instead of returning false after retries
- Remove result==false checks in TranslationFile (fetch/upload/create/delete)
- Timeout now caught by existing rescue StandardError handlers
- All API methods return consistent types regardless of timeout