### PR TITLE
Deduplicate fetch_locales helpers in Pull and Push (#422)

### DIFF
--- a/bin/wti
+++ b/bin/wti
@@ -57,13 +57,11 @@ when 'push'
     opt :locale, 'ISO code of locale(s) to push, space-separated', type: :string
     opt :target, 'Upload all target files'
     opt :force,  'Force push (bypass conditional requests to WTI)'
-    opt :low_priority, 'Deprecated: option to process this file with a low priority'
     opt :merge, 'Force WTI to merge this file'
     opt :ignore_missing, 'Force WTI to not obsolete missing strings'
     opt :minor, 'Minor Changes. When pushing a master file, prevents target translations to be flagged as `to_verify`.'
     opt :label,  'Apply a label to the changes', type: :string
     opt :config, 'Path to a configuration file', short: '-c', default: '.wti'
-    opt :all,    'DEPRECATED -- See `wti push --target` instead'
     opt :debug,  'Display debug information'
   end
 when 'diff'
@@ -78,7 +76,6 @@ when 'diff'
 when 'add'
   Optimist.options do
     banner 'wti add filename - Create and push a new master language file'
-    opt :low_priority, 'Deprecated: option to process this file with a low priority'
     opt :config, 'Path to a configuration file', short: '-c', default: '.wti'
     opt :debug,  'Display debug information'
   end

--- a/history.md
+++ b/history.md
@@ -1,5 +1,7 @@
 ## Edge (unreleased)
 
+* Simplify `fetch_locales` in `Pull` and `Push` commands. Extract `warn_unknown_locales` helper. Remove deprecated `--all` and `--low-priority` options from `push` and `add` commands. #422
+
 * `Util.with_retries` now re-raises `Timeout::Error` after exhausting retries instead of returning `false`. Methods like `find_all`, `find`, `create`, and `update` now return consistent types. #411
 * Standardize `to_hash`/`to_json` pattern across all model classes. Make `to_hash` private in `ApiResource`, `String`, and `Term`. Convert positional boolean to keyword argument. #410
 * Extract threading logic into `Util.concurrent_batch`. Simplify `Pull#pull_files` and fix thread-safety bug with shared mutable state. Use `Thread#value` for error propagation. #409

--- a/lib/web_translate_it/commands/base.rb
+++ b/lib/web_translate_it/commands/base.rb
@@ -35,6 +35,13 @@ module WebTranslateIt
         end
       end
 
+      def warn_unknown_locales(locales)
+        locales.each do |locale|
+          puts "Locale #{locale} doesn't exist -- `wti addlocale #{locale}` to add it." unless configuration.target_locales.include?(locale)
+        end
+        locales
+      end
+
     end
 
   end

--- a/lib/web_translate_it/commands/pull.rb
+++ b/lib/web_translate_it/commands/pull.rb
@@ -51,17 +51,13 @@ module WebTranslateIt
         results.all?
       end
 
-      def fetch_locales # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-        if command_options.locale
-          command_options.locale.split.each do |locale|
-            puts "Locale #{locale} doesn't exist -- `wti addlocale #{locale}` to add it." unless configuration.target_locales.include?(locale)
-          end
-          locales = command_options.locale.split
+      def fetch_locales # rubocop:todo Metrics/AbcSize
+        locales = if command_options.locale
+          warn_unknown_locales(command_options.locale.split)
         elsif configuration.needed_locales.any?
-          locales = configuration.needed_locales
+          configuration.needed_locales
         else
-          locales = configuration.target_locales
-          configuration.ignore_locales.each { |locale_to_delete| locales.delete(locale_to_delete) } if configuration.ignore_locales.any?
+          configuration.target_locales - configuration.ignore_locales
         end
         locales.push(configuration.source_locale) if command_options.all
         locales.uniq

--- a/lib/web_translate_it/commands/push.rb
+++ b/lib/web_translate_it/commands/push.rb
@@ -7,7 +7,6 @@ module WebTranslateIt
     class Push < Base
 
       def call # rubocop:todo Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        puts 'The `--low-priority` option in `wti push --low-priority` was removed and does nothing' if command_options.low_priority
         complete_success = true
         $stdout.sync = true
         run_hook(configuration.before_push, 'before_push')
@@ -35,22 +34,14 @@ module WebTranslateIt
 
       private
 
-      def fetch_locales # rubocop:todo Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def fetch_locales
         if command_options.locale
-          command_options.locale.split.each do |locale|
-            puts "Locale #{locale} doesn't exist -- `wti addlocale #{locale}` to add it." unless configuration.target_locales.include?(locale)
-          end
-          locales = command_options.locale.split
-        else
-          locales = [configuration.source_locale]
-        end
-        if command_options.all
-          puts '`wti push --all` was deprecated in wti 2.3. Use `wti push --target` instead.'
-          return []
+          warn_unknown_locales(command_options.locale.split)
         elsif command_options.target
-          locales = configuration.target_locales.reject { |locale| locale == configuration.source_locale }
+          configuration.target_locales.reject { |locale| locale == configuration.source_locale }
+        else
+          [configuration.source_locale]
         end
-        locales.uniq
       end
 
     end


### PR DESCRIPTION
- Simplify Push#fetch_locales: remove deprecated --all handling, clean 3-branch conditional (locale/target/source-only)
- Simplify Pull#fetch_locales: replace imperative ignore_locales deletion with array subtraction
- Move shared warn_unknown_locales to Base
- Remove deprecated --low-priority option from push and add commands
- Remove deprecated --all option from push command