### PR TITLE
Eliminate HTTP request boilerplate with Connection wrappers (#424)

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,5 +1,7 @@
 ## Edge (unreleased)
 
+* Add `Connection#get`, `#post`, `#put`, `#delete` wrappers to eliminate repeated `Net::HTTP::*.new` / `Util.add_fields` / `http_connection.request` boilerplate across all API call sites. #424
+
 * Simplify `fetch_locales` in `Pull` and `Push` commands. Extract `warn_unknown_locales` helper. Remove deprecated `--all` and `--low-priority` options from `push` and `add` commands. #422
 
 * Extract `TranslationBase` base class from `Translation` and `TermTranslation` to share `initialize`, `save`, `to_json`, and API path logic. #425

--- a/lib/web_translate_it.rb
+++ b/lib/web_translate_it.rb
@@ -50,7 +50,7 @@ module WebTranslateIt
     config.logger&.debug { "   Fetching #{locale} language file(s) from WebTranslateIt" }
     WebTranslateIt::Connection.new(config.api_key) do |conn|
       config.files.find_all { |file| file.locale.in?([locale, I18n.locale]) }.each do |file|
-        file.fetch(conn.http_connection)
+        file.fetch(conn)
       end
     end
   end

--- a/lib/web_translate_it/api_resource.rb
+++ b/lib/web_translate_it/api_resource.rb
@@ -22,12 +22,10 @@ module WebTranslateIt
       url = "/api/projects/#{connection.api_key}/#{resource_path}"
       url += "?#{HashUtil.to_params(filter_params(params))}" unless params.empty?
 
-      request = Net::HTTP::Get.new(url)
-      WebTranslateIt::Util.add_fields(request)
       Util.with_retries do
         records = []
-        while request
-          response = connection.http_connection.request(request)
+        loop do
+          response = connection.get(url)
           return [] unless response.code.to_i < 400
 
           JSON.parse(response.body).each do |record_response|
@@ -35,23 +33,17 @@ module WebTranslateIt
             record.new_record = false
             records.push(record)
           end
-          if response['Link']&.include?('rel="next"')
-            url = response['Link'].match(/<(.*)>; rel="next"/)[1]
-            request = Net::HTTP::Get.new(url)
-            WebTranslateIt::Util.add_fields(request)
-          else
-            request = nil
-          end
+          break unless response['Link']&.include?('rel="next"')
+
+          url = response['Link'].match(/<(.*)>; rel="next"/)[1]
         end
-        return records
+        records
       end
     end
 
     def self.find(connection, id)
-      request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/#{resource_path}/#{id}")
-      WebTranslateIt::Util.add_fields(request)
       Util.with_retries do
-        response = connection.http_connection.request(request)
+        response = connection.get("/api/projects/#{connection.api_key}/#{resource_path}/#{id}")
         return nil if response.code.to_i == 404
 
         record = new(JSON.parse(response.body), connection: connection)
@@ -73,22 +65,18 @@ module WebTranslateIt
     end
 
     def delete
-      request = Net::HTTP::Delete.new("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}")
-      WebTranslateIt::Util.add_fields(request)
       Util.with_retries do
-        Util.handle_response(connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.delete("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}"), true, true)
       end
     end
 
-    def translation_for(locale) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
+    def translation_for(locale) # rubocop:todo Metrics/AbcSize
       translation = translations.detect { |t| t.locale == locale }
       return translation if translation
       return nil if new_record
 
-      request = Net::HTTP::Get.new("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}/locales/#{locale}/translations")
-      WebTranslateIt::Util.add_fields(request)
       Util.with_retries do
-        response = Util.handle_response(connection.http_connection.request(request), true, true)
+        response = Util.handle_response(connection.get("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}/locales/#{locale}/translations"), true, true)
         json = JSON.parse(response)
         return nil if json.empty?
 
@@ -110,11 +98,7 @@ module WebTranslateIt
       raise NotImplementedError, "#{self.class.name} must implement assign_translation_parent_id"
     end
 
-    def update # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      request = Net::HTTP::Put.new("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}")
-      WebTranslateIt::Util.add_fields(request)
-      request.body = to_json
-
+    def update
       translations.each do |translation|
         assign_translation_parent_id(translation)
         translation.connection = connection
@@ -122,16 +106,14 @@ module WebTranslateIt
       end
 
       Util.with_retries do
-        Util.handle_response(connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.put("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}", body: to_json), true, true)
       end
     end
 
-    def create # rubocop:todo Metrics/AbcSize
-      request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/#{self.class.resource_path}")
-      WebTranslateIt::Util.add_fields(request)
-      request.body = to_json(with_translations: true)
+    def create
       Util.with_retries do
-        response = JSON.parse(Util.handle_response(connection.http_connection.request(request), true, true))
+        raw = connection.post("/api/projects/#{connection.api_key}/#{self.class.resource_path}", body: to_json(with_translations: true))
+        response = JSON.parse(Util.handle_response(raw, true, true))
         self.id = response['id']
         self.new_record = false
         return true

--- a/lib/web_translate_it/commands/add.rb
+++ b/lib/web_translate_it/commands/add.rb
@@ -20,7 +20,7 @@ module WebTranslateIt
           if to_add.any?
             to_add.each do |param|
               file = TranslationFile.new(nil, param.gsub(/ /, '\\ '), nil, configuration.api_key)
-              result = file.create(conn.http_connection)
+              result = file.create(conn)
               puts StringUtil.array_to_columns(result.output)
               complete_success = false unless result.success
             end

--- a/lib/web_translate_it/commands/diff.rb
+++ b/lib/web_translate_it/commands/diff.rb
@@ -36,7 +36,7 @@ module WebTranslateIt
           return false
         end
 
-        remote_content = file.fetch_remote_content(conn.http_connection)
+        remote_content = file.fetch_remote_content(conn)
         unless remote_content
           puts StringUtil.failure("Couldn't fetch remote file #{file.file_path}")
           return false

--- a/lib/web_translate_it/commands/mv.rb
+++ b/lib/web_translate_it/commands/mv.rb
@@ -29,7 +29,7 @@ module WebTranslateIt
 
         complete_success = true
         configuration.files.find_all { |file| file.file_path == source }.each do |master_file|
-          result = master_file.upload(conn.http_connection, force: true, rename_others: true, destination_path: destination)
+          result = master_file.upload(conn, force: true, rename_others: true, destination_path: destination)
           puts StringUtil.array_to_columns(result.output)
           if File.exist?(source)
             File.rename(source, destination)
@@ -43,7 +43,7 @@ module WebTranslateIt
           end
           configuration.reload
           configuration.files.find_all { |file| file.master_id == master_file.id }.each do |target_file|
-            result = target_file.fetch(conn.http_connection)
+            result = target_file.fetch(conn)
             print StringUtil.array_to_columns(result.output)
             complete_success = false unless result.success
           end

--- a/lib/web_translate_it/commands/pull.rb
+++ b/lib/web_translate_it/commands/pull.rb
@@ -40,7 +40,7 @@ module WebTranslateIt
         results, n_threads = Util.concurrent_batch(files) do |batch|
           with_connection do |conn|
             batch.map do |file|
-              result = file.fetch(conn.http_connection, command_options.force)
+              result = file.fetch(conn, command_options.force)
               print StringUtil.array_to_columns(result.output)
               result.success
             end

--- a/lib/web_translate_it/commands/push.rb
+++ b/lib/web_translate_it/commands/push.rb
@@ -21,7 +21,7 @@ module WebTranslateIt
               puts "Couldn't find any local files registered on WebTranslateIt to push."
             else
               files.each do |file|
-                result = file.upload(conn.http_connection, merge: command_options[:merge], ignore_missing: command_options.ignore_missing, label: command_options.label, minor_changes: command_options[:minor], force: command_options.force)
+                result = file.upload(conn, merge: command_options[:merge], ignore_missing: command_options.ignore_missing, label: command_options.label, minor_changes: command_options[:minor], force: command_options.force)
                 puts StringUtil.array_to_columns(result.output)
                 complete_success = false unless result.success
               end

--- a/lib/web_translate_it/commands/rm.rb
+++ b/lib/web_translate_it/commands/rm.rb
@@ -35,7 +35,7 @@ module WebTranslateIt
 
         complete_success = true
         files.each do |master_file|
-          result = master_file.delete(conn.http_connection)
+          result = master_file.delete(conn)
           puts StringUtil.array_to_columns(result.output)
           if File.exist?(master_file.file_path)
             File.delete(master_file.file_path)

--- a/lib/web_translate_it/connection.rb
+++ b/lib/web_translate_it/connection.rb
@@ -47,6 +47,32 @@ module WebTranslateIt
       @debug = true
     end
 
+    def get(path)
+      api_request(Net::HTTP::Get, path)
+    end
+
+    def post(path, body: nil, &block)
+      api_request(Net::HTTP::Post, path, body: body, &block)
+    end
+
+    def put(path, body: nil, &block)
+      api_request(Net::HTTP::Put, path, body: body, &block)
+    end
+
+    def delete(path)
+      api_request(Net::HTTP::Delete, path)
+    end
+
+    private
+
+    def api_request(method_class, path, body: nil)
+      request = method_class.new(path)
+      Util.add_fields(request)
+      request.body = body if body
+      yield request if block_given?
+      http_connection.request(request)
+    end
+
   end
 
 end

--- a/lib/web_translate_it/project.rb
+++ b/lib/web_translate_it/project.rb
@@ -7,9 +7,7 @@ module WebTranslateIt
     def self.fetch_info(api_key) # rubocop:todo Metrics/MethodLength
       Util.with_retries do
         WebTranslateIt::Connection.new(api_key) do |conn|
-          request = Net::HTTP::Get.new("/api/projects/#{api_key}")
-          WebTranslateIt::Util.add_fields(request)
-          response = conn.http_connection.request(request)
+          response = conn.get("/api/projects/#{api_key}")
           return response.body if response.is_a?(Net::HTTPSuccess)
 
           puts 'An error occured while fetching the project information:'
@@ -26,27 +24,21 @@ module WebTranslateIt
       url = file_id.nil? ? "/api/projects/#{api_key}/stats" : "/api/projects/#{api_key}/stats?file=#{file_id}"
       Util.with_retries do
         WebTranslateIt::Connection.new(api_key) do |conn|
-          request = Net::HTTP::Get.new(url)
-          WebTranslateIt::Util.add_fields(request)
-          return Util.handle_response(conn.http_connection.request(request), true)
+          return Util.handle_response(conn.get(url), true)
         end
       end
     end
 
     def self.create_locale(connection, locale_code)
       Util.with_retries do
-        request = Net::HTTP::Post.new("/api/projects/#{connection.api_key}/locales")
-        WebTranslateIt::Util.add_fields(request)
-        request.set_form_data({'id' => locale_code}, ';')
-        Util.handle_response(connection.http_connection.request(request), true)
+        response = connection.post("/api/projects/#{connection.api_key}/locales") { |req| req.set_form_data({'id' => locale_code}, ';') }
+        Util.handle_response(response, true)
       end
     end
 
     def self.delete_locale(connection, locale_code)
       Util.with_retries do
-        request = Net::HTTP::Delete.new("/api/projects/#{connection.api_key}/locales/#{locale_code}")
-        WebTranslateIt::Util.add_fields(request)
-        Util.handle_response(connection.http_connection.request(request), true)
+        Util.handle_response(connection.delete("/api/projects/#{connection.api_key}/locales/#{locale_code}"), true)
       end
     end
 

--- a/lib/web_translate_it/term_translation.rb
+++ b/lib/web_translate_it/term_translation.rb
@@ -32,12 +32,9 @@ module WebTranslateIt
     end
 
     def create
-      request = Net::HTTP::Post.new(translation_path)
-      WebTranslateIt::Util.add_fields(request)
-      request.body = to_json
-
       Util.with_retries do
-        response = JSON.parse(Util.handle_response(connection.http_connection.request(request), true, true))
+        raw = connection.post(translation_path, body: to_json)
+        response = JSON.parse(Util.handle_response(raw, true, true))
         self.id = response['id']
         self.new_record = false
         return true
@@ -45,11 +42,8 @@ module WebTranslateIt
     end
 
     def update
-      request = Net::HTTP::Put.new("/api/projects/#{connection.api_key}/terms/#{id}/locales/#{locale}/translations/#{id}")
-      WebTranslateIt::Util.add_fields(request)
-      request.body = to_json
       Util.with_retries do
-        Util.handle_response(connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.put("/api/projects/#{connection.api_key}/terms/#{id}/locales/#{locale}/translations/#{id}", body: to_json), true, true)
       end
     end
 

--- a/lib/web_translate_it/translation_base.rb
+++ b/lib/web_translate_it/translation_base.rb
@@ -16,11 +16,8 @@ module WebTranslateIt
     end
 
     def save
-      request = Net::HTTP::Post.new(translation_path)
-      WebTranslateIt::Util.add_fields(request)
-      request.body = to_json
       Util.with_retries do
-        Util.handle_response(connection.http_connection.request(request), true, true)
+        Util.handle_response(connection.post(translation_path, body: to_json), true, true)
       end
     end
 

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -50,7 +50,7 @@ module WebTranslateIt
     #   file.fetch # returns nothing, with a status 304 Not Modified
     #   file.fetch(true) # force to re-download the file, will return the content of the file with a 200 OK
     #
-    def fetch(http_connection, force = false) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def fetch(connection, force = false) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
       success = true
       display = []
       if fresh
@@ -61,13 +61,11 @@ module WebTranslateIt
       display.push "#{StringUtil.checksumify(local_checksum.to_s)}..#{StringUtil.checksumify(remote_checksum.to_s)}"
       if !File.exist?(file_path) || force || (remote_checksum != local_checksum)
 
-        request = Net::HTTP::Get.new(api_url)
-        WebTranslateIt::Util.add_fields(request)
         dir = File.dirname(file_path)
         FileUtils.mkpath(dir) unless File.exist?(file_path) || dir == '.'
         begin
           Util.with_retries do
-            response = http_connection.request(request)
+            response = connection.get(api_url)
             File.open(file_path, 'wb') { |file| file << response.body } if response.code.to_i == 200
             display.push Util.handle_response(response)
           end
@@ -82,10 +80,8 @@ module WebTranslateIt
       Result.new(success, display)
     end
 
-    def fetch_remote_content(http_connection)
-      request = Net::HTTP::Get.new(api_url)
-      WebTranslateIt::Util.add_fields(request)
-      response = http_connection.request(request)
+    def fetch_remote_content(connection)
+      response = connection.get(api_url)
       response.body if response.code.to_i == 200
     end
 
@@ -102,7 +98,7 @@ module WebTranslateIt
     # actually takes place. This is due to the fact that language file imports are handled by background processing.
     # rubocop:todo Metrics/MethodLength
     # rubocop:todo Metrics/AbcSize
-    def upload(http_connection, merge: false, ignore_missing: false, label: nil, minor_changes: false, force: false, rename_others: false, destination_path: nil) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
+    def upload(connection, merge: false, ignore_missing: false, label: nil, minor_changes: false, force: false, rename_others: false, destination_path: nil) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       display = []
       display.push(file_path)
@@ -119,11 +115,8 @@ module WebTranslateIt
               ['file', file]
             ]
             params += [['name', destination_path]] unless destination_path.nil?
-            request = Net::HTTP::Put.new(api_url)
-            WebTranslateIt::Util.add_fields(request)
-            request.set_form params, 'multipart/form-data'
             Util.with_retries do
-              display.push Util.handle_response(http_connection.request(request))
+              display.push Util.handle_response(connection.put(api_url) { |req| req.set_form params, 'multipart/form-data' })
             end
           rescue StandardError => e
             display.push StringUtil.failure("An error occured: #{e.message}")
@@ -151,20 +144,16 @@ module WebTranslateIt
     # Note that the request might or might not eventually be acted upon, as it might be disallowed when processing
     # actually takes place. This is due to the fact that language file imports are handled by background processing.
     #
-    def create(http_connection) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
+    def create(connection) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       success = true
       display = []
       display.push file_path
       display.push "#{StringUtil.checksumify(local_checksum.to_s)}..[     ]"
       if File.exist?(file_path)
         File.open(file_path) do |file|
-          params = [['name', file_path]]
-          params += [['file', file]]
-          request = Net::HTTP::Post.new(api_url_for_create)
-          WebTranslateIt::Util.add_fields(request)
-          request.set_form params, 'multipart/form-data'
+          params = [['name', file_path], ['file', file]]
           Util.with_retries do
-            display.push Util.handle_response(http_connection.request(request))
+            display.push Util.handle_response(connection.post(api_url_for_create) { |req| req.set_form params, 'multipart/form-data' })
           end
         rescue StandardError => e
           display.push StringUtil.failure("An error occured: #{e.message}")
@@ -178,16 +167,14 @@ module WebTranslateIt
 
     # Delete a master language file from Web Translate It by performing a DELETE Request.
     #
-    def delete(http_connection) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
+    def delete(connection) # rubocop:todo Metrics/MethodLength
       success = true
       display = []
       display.push file_path
       if File.exist?(file_path)
         begin
-          request = Net::HTTP::Delete.new(api_url_for_delete)
-          WebTranslateIt::Util.add_fields(request)
           Util.with_retries do
-            display.push Util.handle_response(http_connection.request(request))
+            display.push Util.handle_response(connection.delete(api_url_for_delete))
           end
         rescue StandardError => e
           display.push StringUtil.failure("An error occured: #{e.message}")

--- a/spec/web_translate_it/connection_spec.rb
+++ b/spec/web_translate_it/connection_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe WebTranslateIt::Connection do
+  let(:api_key) { 'test_api_key' }
+  let(:base_url) { 'https://webtranslateit.com' }
+  let!(:connection) { described_class.new(api_key) }
+
+  describe '#get' do
+    it 'performs a GET request and returns the response' do
+      stub_request(:get, "#{base_url}/api/projects/#{api_key}")
+        .to_return(status: 200, body: '{"name":"My Project"}')
+
+      response = connection.get("/api/projects/#{api_key}")
+
+      expect(response.code).to eq '200'
+      expect(response.body).to eq '{"name":"My Project"}'
+    end
+
+    it 'returns error responses without raising' do
+      stub_request(:get, "#{base_url}/api/projects/#{api_key}")
+        .to_return(status: 404, body: 'Not Found')
+
+      response = connection.get("/api/projects/#{api_key}")
+
+      expect(response.code).to eq '404'
+    end
+  end
+
+  describe '#post' do
+    it 'performs a POST request with a JSON body' do
+      stub_request(:post, "#{base_url}/api/projects/#{api_key}/terms")
+        .with(body: '{"text":"Hello"}')
+        .to_return(status: 201, body: '{"id":1,"text":"Hello"}')
+
+      response = connection.post("/api/projects/#{api_key}/terms", body: '{"text":"Hello"}')
+
+      expect(response.code).to eq '201'
+      expect(response.body).to eq '{"id":1,"text":"Hello"}'
+    end
+
+    it 'yields the request for custom setup' do
+      stub_request(:post, "#{base_url}/api/projects/#{api_key}/locales")
+        .to_return(status: 201, body: '{}')
+
+      yielded_request = nil
+      connection.post("/api/projects/#{api_key}/locales") do |req|
+        yielded_request = req
+        req.set_form_data({'id' => 'fr'}, ';')
+      end
+
+      expect(yielded_request).to be_a Net::HTTP::Post
+    end
+  end
+
+  describe '#put' do
+    it 'performs a PUT request with a JSON body' do
+      stub_request(:put, "#{base_url}/api/projects/#{api_key}/terms/1")
+        .with(body: '{"text":"Updated"}')
+        .to_return(status: 200, body: '{"id":1,"text":"Updated"}')
+
+      response = connection.put("/api/projects/#{api_key}/terms/1", body: '{"text":"Updated"}')
+
+      expect(response.code).to eq '200'
+    end
+
+    it 'yields the request for multipart form setup' do
+      stub_request(:put, "#{base_url}/api/projects/#{api_key}/files/1/locales/en")
+        .to_return(status: 200, body: '{}')
+
+      yielded_request = nil
+      connection.put("/api/projects/#{api_key}/files/1/locales/en") do |req|
+        yielded_request = req
+      end
+
+      expect(yielded_request).to be_a Net::HTTP::Put
+    end
+  end
+
+  describe '#delete' do
+    it 'performs a DELETE request' do
+      stub_request(:delete, "#{base_url}/api/projects/#{api_key}/terms/1")
+        .to_return(status: 200, body: '{}')
+
+      response = connection.delete("/api/projects/#{api_key}/terms/1")
+
+      expect(response.code).to eq '200'
+    end
+  end
+
+  describe '#initialize' do
+    it 'exposes the api_key' do
+      expect(connection.api_key).to eq api_key
+    end
+
+    it 'yields itself when a block is given' do
+      yielded = nil
+      described_class.new(api_key) { |conn| yielded = conn }
+
+      expect(yielded).to be_a described_class
+    end
+  end
+end

--- a/spec/web_translate_it/translation_file_spec.rb
+++ b/spec/web_translate_it/translation_file_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 
 describe WebTranslateIt::TranslationFile do
   let(:api_key) { 'test_api_key' }
-  let(:http_connection) { instance_double(Net::HTTP) }
+  let(:connection) { instance_double(WebTranslateIt::Connection) }
   let(:ok_response) do
     instance_double(Net::HTTPSuccess, code: '200', body: 'file content', :[] => nil)
   end
 
   before do
-    allow(http_connection).to receive(:request).and_return(ok_response)
+    allow(connection).to receive(:get).and_return(ok_response)
   end
 
   describe '#fetch' do
@@ -23,7 +23,7 @@ describe WebTranslateIt::TranslationFile do
         allow(File).to receive(:open).with('config/locales/app/en.yml', 'wb').and_yield(StringIO.new)
         allow(FileUtils).to receive(:mkpath)
 
-        file.fetch(http_connection, true)
+        file.fetch(connection, true)
 
         expect(FileUtils).to have_received(:mkpath).with('config/locales/app')
       end
@@ -38,7 +38,7 @@ describe WebTranslateIt::TranslationFile do
         allow(File).to receive(:open).with('en.yml', 'wb').and_yield(StringIO.new)
         allow(FileUtils).to receive(:mkpath)
 
-        file.fetch(http_connection, true)
+        file.fetch(connection, true)
 
         expect(FileUtils).not_to have_received(:mkpath)
       end
@@ -53,7 +53,7 @@ describe WebTranslateIt::TranslationFile do
         allow(File).to receive(:open).with('config/locales/en.yml', 'wb').and_yield(StringIO.new)
         allow(FileUtils).to receive(:mkpath)
 
-        file.fetch(http_connection, true)
+        file.fetch(connection, true)
 
         expect(FileUtils).not_to have_received(:mkpath)
       end


### PR DESCRIPTION
Add Connection#get, #post, #put, #delete methods backed by a private api_request helper. This consolidates the repeated Net::HTTP::*.new → Util.add_fields → http_connection.request pattern (18 call sites across 6 files) into a single location.

- post/put accept blocks for multipart form setup
- TranslationFile methods now receive Connection instead of raw Net::HTTP
- All command callers pass conn directly instead of conn.http_connection
- Removed stale rubocop disables where simplification lowered complexity