### PR TITLE
Refactor Util.handle_response: split into focused methods

### DIFF
--- a/lib/web_translate_it/api_resource.rb
+++ b/lib/web_translate_it/api_resource.rb
@@ -66,7 +66,7 @@ module WebTranslateIt
 
     def delete
       Util.with_retries do
-        Util.handle_response(connection.delete("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}"), true, true)
+        Util.handle_response(connection.delete("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}"))
       end
     end
 
@@ -76,7 +76,7 @@ module WebTranslateIt
       return nil if new_record
 
       Util.with_retries do
-        response = Util.handle_response(connection.get("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}/locales/#{locale}/translations"), true, true)
+        response = Util.handle_response(connection.get("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}/locales/#{locale}/translations"))
         json = JSON.parse(response)
         return nil if json.empty?
 
@@ -106,14 +106,14 @@ module WebTranslateIt
       end
 
       Util.with_retries do
-        Util.handle_response(connection.put("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}", body: to_json), true, true)
+        Util.handle_response(connection.put("/api/projects/#{connection.api_key}/#{self.class.resource_path}/#{id}", body: to_json))
       end
     end
 
     def create
       Util.with_retries do
         raw = connection.post("/api/projects/#{connection.api_key}/#{self.class.resource_path}", body: to_json(with_translations: true))
-        response = JSON.parse(Util.handle_response(raw, true, true))
+        response = JSON.parse(Util.handle_response(raw))
         self.id = response['id']
         self.new_record = false
         return true

--- a/lib/web_translate_it/project.rb
+++ b/lib/web_translate_it/project.rb
@@ -4,27 +4,19 @@ module WebTranslateIt
 
   class Project
 
-    def self.fetch_info(api_key) # rubocop:todo Metrics/MethodLength
+    def self.fetch_info(api_key)
       Util.with_retries do
         WebTranslateIt::Connection.new(api_key) do |conn|
-          response = conn.get("/api/projects/#{api_key}")
-          return response.body if response.is_a?(Net::HTTPSuccess)
-
-          puts 'An error occured while fetching the project information:'
-          puts StringUtil.failure(response.body)
-          exit 1
+          return Util.handle_response(conn.get("/api/projects/#{api_key}"))
         end
       end
-    rescue StandardError => e
-      puts e.inspect
-      raise
     end
 
     def self.fetch_stats(api_key, file_id = nil)
       url = file_id.nil? ? "/api/projects/#{api_key}/stats" : "/api/projects/#{api_key}/stats?file=#{file_id}"
       Util.with_retries do
         WebTranslateIt::Connection.new(api_key) do |conn|
-          return Util.handle_response(conn.get(url), true)
+          return Util.handle_response(conn.get(url))
         end
       end
     end
@@ -32,13 +24,13 @@ module WebTranslateIt
     def self.create_locale(connection, locale_code)
       Util.with_retries do
         response = connection.post("/api/projects/#{connection.api_key}/locales") { |req| req.set_form_data({'id' => locale_code}, ';') }
-        Util.handle_response(response, true)
+        Util.handle_response(response)
       end
     end
 
     def self.delete_locale(connection, locale_code)
       Util.with_retries do
-        Util.handle_response(connection.delete("/api/projects/#{connection.api_key}/locales/#{locale_code}"), true)
+        Util.handle_response(connection.delete("/api/projects/#{connection.api_key}/locales/#{locale_code}"))
       end
     end
 

--- a/lib/web_translate_it/term_translation.rb
+++ b/lib/web_translate_it/term_translation.rb
@@ -34,7 +34,7 @@ module WebTranslateIt
     def create
       Util.with_retries do
         raw = connection.post(translation_path, body: to_json)
-        response = JSON.parse(Util.handle_response(raw, true, true))
+        response = JSON.parse(Util.handle_response(raw))
         self.id = response['id']
         self.new_record = false
         return true
@@ -43,7 +43,7 @@ module WebTranslateIt
 
     def update
       Util.with_retries do
-        Util.handle_response(connection.put("/api/projects/#{connection.api_key}/terms/#{id}/locales/#{locale}/translations/#{id}", body: to_json), true, true)
+        Util.handle_response(connection.put("/api/projects/#{connection.api_key}/terms/#{id}/locales/#{locale}/translations/#{id}", body: to_json))
       end
     end
 

--- a/lib/web_translate_it/translation_base.rb
+++ b/lib/web_translate_it/translation_base.rb
@@ -17,7 +17,7 @@ module WebTranslateIt
 
     def save
       Util.with_retries do
-        Util.handle_response(connection.post(translation_path, body: to_json), true, true)
+        Util.handle_response(connection.post(translation_path, body: to_json))
       end
     end
 

--- a/lib/web_translate_it/translation_file.rb
+++ b/lib/web_translate_it/translation_file.rb
@@ -51,7 +51,6 @@ module WebTranslateIt
     #   file.fetch(true) # force to re-download the file, will return the content of the file with a 200 OK
     #
     def fetch(connection, force = false) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-      success = true
       display = []
       if fresh
         display.push(file_path)
@@ -63,21 +62,16 @@ module WebTranslateIt
 
         dir = File.dirname(file_path)
         FileUtils.mkpath(dir) unless File.exist?(file_path) || dir == '.'
-        begin
-          Util.with_retries do
-            response = connection.get(api_url)
-            File.open(file_path, 'wb') { |file| file << response.body } if response.code.to_i == 200
-            display.push Util.handle_response(response)
-          end
-        rescue StandardError => e
-          display.push StringUtil.failure("An error occured: #{e.message}")
-          success = false
+        with_display(display) do
+          response = connection.get(api_url)
+          File.open(file_path, 'wb') { |file| file << response.body } if response.code.to_i == 200
+          response
         end
 
       else
         display.push StringUtil.success('Skipped')
+        Result.new(true, display)
       end
-      Result.new(success, display)
     end
 
     def fetch_remote_content(connection)
@@ -96,10 +90,9 @@ module WebTranslateIt
     #
     # Note that the request might or might not eventually be acted upon, as it might be disallowed when processing
     # actually takes place. This is due to the fact that language file imports are handled by background processing.
-    # rubocop:todo Metrics/MethodLength
     # rubocop:todo Metrics/AbcSize
+    # rubocop:todo Metrics/MethodLength
     def upload(connection, merge: false, ignore_missing: false, label: nil, minor_changes: false, force: false, rename_others: false, destination_path: nil) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      success = true
       display = []
       display.push(file_path)
       display.push "#{StringUtil.checksumify(local_checksum.to_s)}..#{StringUtil.checksumify(remote_checksum.to_s)}"
@@ -115,12 +108,9 @@ module WebTranslateIt
               ['file', file]
             ]
             params += [['name', destination_path]] unless destination_path.nil?
-            Util.with_retries do
-              display.push Util.handle_response(connection.put(api_url) { |req| req.set_form params, 'multipart/form-data' })
+            return with_display(display) do
+              connection.put(api_url) { |req| req.set_form params, 'multipart/form-data' }
             end
-          rescue StandardError => e
-            display.push StringUtil.failure("An error occured: #{e.message}")
-            success = false
           end
         else
           display.push StringUtil.success('Skipped')
@@ -128,11 +118,11 @@ module WebTranslateIt
       else
         display.push StringUtil.failure("Can't push #{file_path}. File doesn't exist locally.")
       end
-      Result.new(success, display)
+      Result.new(true, display)
     end
 
-    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
     # Create a master language file to Web Translate It by performing a POST Request.
     #
     # Example of implementation:
@@ -145,45 +135,33 @@ module WebTranslateIt
     # actually takes place. This is due to the fact that language file imports are handled by background processing.
     #
     def create(connection) # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
-      success = true
       display = []
       display.push file_path
       display.push "#{StringUtil.checksumify(local_checksum.to_s)}..[     ]"
       if File.exist?(file_path)
         File.open(file_path) do |file|
           params = [['name', file_path], ['file', file]]
-          Util.with_retries do
-            display.push Util.handle_response(connection.post(api_url_for_create) { |req| req.set_form params, 'multipart/form-data' })
+          return with_display(display) do
+            connection.post(api_url_for_create) { |req| req.set_form params, 'multipart/form-data' }
           end
-        rescue StandardError => e
-          display.push StringUtil.failure("An error occured: #{e.message}")
-          success = false
         end
       else
         display.push StringUtil.failure("File #{file_path} doesn't exist locally!")
       end
-      Result.new(success, display)
+      Result.new(true, display)
     end
 
     # Delete a master language file from Web Translate It by performing a DELETE Request.
     #
-    def delete(connection) # rubocop:todo Metrics/MethodLength
-      success = true
+    def delete(connection)
       display = []
       display.push file_path
       if File.exist?(file_path)
-        begin
-          Util.with_retries do
-            display.push Util.handle_response(connection.delete(api_url_for_delete))
-          end
-        rescue StandardError => e
-          display.push StringUtil.failure("An error occured: #{e.message}")
-          success = false
-        end
+        with_display(display) { connection.delete(api_url_for_delete) }
       else
         display.push StringUtil.failure("Master file #{file_path} doesn't exist locally!")
+        Result.new(true, display)
       end
-      Result.new(success, display)
     end
 
     def exists?
@@ -214,6 +192,19 @@ module WebTranslateIt
       Digest::SHA1.hexdigest(File.read(file_path))
     rescue StandardError => _e
       ''
+    end
+
+    private
+
+    def with_display(display)
+      Util.with_retries do
+        response = yield
+        display.push Util.status_label(response)
+      end
+      Result.new(true, display)
+    rescue StandardError => e
+      display.push StringUtil.failure("An error occured: #{e.message}")
+      Result.new(false, display)
     end
 
   end

--- a/lib/web_translate_it/util.rb
+++ b/lib/web_translate_it/util.rb
@@ -17,31 +17,37 @@ module WebTranslateIt
       ((processed * 10) / total).to_f.ceil * 10
     end
 
-    # rubocop:todo Metrics/PerceivedComplexity
-    # rubocop:todo Metrics/MethodLength
-    # rubocop:todo Metrics/AbcSize
-    def self.handle_response(response, return_response = false, raise_exception = false) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-      if (response.code.to_i >= 400) && (response.code.to_i < 500)
-        raise "Error: #{MultiJson.load(response.body)['error']}" if raise_exception
+    def self.handle_response(response)
+      raise_on_error!(response)
+      response.body
+    end
 
-        puts StringUtil.failure(MultiJson.load(response.body)['error'])
-      elsif response.code.to_i == 500
-        raise 'Error: Server temporarily unavailable (Error 500).' if raise_exception
+    STATUS_LABELS = {
+      200 => 'OK',
+      201 => 'Created',
+      202 => 'Accepted',
+      304 => 'Not Modified'
+    }.freeze
 
-        puts StringUtil.failure('Error: Server temporarily unavailable (Error 500).')
-      else
-        return response.body if return_response
-        return StringUtil.success('OK') if response.code.to_i == 200
-        return StringUtil.success('Created') if response.code.to_i == 201
-        return StringUtil.success('Accepted') if response.code.to_i == 202
-        return StringUtil.success('Not Modified') if response.code.to_i == 304
+    def self.status_label(response)
+      raise_on_error!(response)
+      label = STATUS_LABELS[response.code.to_i]
+      StringUtil.success(label || 'OK')
+    rescue RuntimeError => e
+      StringUtil.failure(e.message)
+    end
 
-        StringUtil.failure("Locked\n                                                    (another import in progress)") if response.code.to_i == 503
+    def self.raise_on_error!(response)
+      code = response.code.to_i
+      if code >= 400 && code < 500
+        raise "Error: #{MultiJson.load(response.body)['error']}"
+      elsif code == 500
+        raise 'Error: Server temporarily unavailable (Error 500).'
+      elsif code == 503
+        raise 'Error: Locked (another import in progress)'
       end
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/PerceivedComplexity
+    private_class_method :raise_on_error!
 
     def self.add_fields(request)
       request.add_field('User-Agent', "wti v#{version}")
@@ -53,7 +59,7 @@ module WebTranslateIt
     def self.with_retries(retries: 3, delay: 5)
       yield
     rescue Timeout::Error
-      puts 'Request timeout. Will retry in 5 seconds.'
+      puts "Request timeout. Will retry in #{delay} seconds."
       if (retries -= 1).positive?
         sleep(delay)
         retry

--- a/spec/web_translate_it/util_spec.rb
+++ b/spec/web_translate_it/util_spec.rb
@@ -43,7 +43,7 @@ describe WebTranslateIt::Util do
         described_class.with_retries(retries: 2, delay: 0) { raise Timeout::Error }
       rescue Timeout::Error
         # expected
-      end.to output("Request timeout. Will retry in 5 seconds.\n" * 2).to_stdout
+      end.to output("Request timeout. Will retry in 0 seconds.\n" * 2).to_stdout
     end
 
     it 'defaults to 3 retries' do
@@ -57,6 +57,75 @@ describe WebTranslateIt::Util do
         # expected
       end
       expect(attempts).to eq 3
+    end
+  end
+
+  describe '.handle_response' do
+    def fake_response(code, body = '{}')
+      instance_double(Net::HTTPResponse, code: code.to_s, body: body)
+    end
+
+    it 'returns response body on 200' do
+      expect(described_class.handle_response(fake_response(200, 'OK body'))).to eq 'OK body'
+    end
+
+    it 'returns response body on 201' do
+      expect(described_class.handle_response(fake_response(201, '{"id":1}'))).to eq '{"id":1}'
+    end
+
+    it 'returns response body on 304' do
+      expect(described_class.handle_response(fake_response(304, ''))).to eq ''
+    end
+
+    it 'raises on 4xx with error message from body' do
+      body = MultiJson.dump('error' => 'Not found')
+      expect { described_class.handle_response(fake_response(404, body)) }
+        .to raise_error(RuntimeError, 'Error: Not found')
+    end
+
+    it 'raises on 500' do
+      expect { described_class.handle_response(fake_response(500)) }
+        .to raise_error(RuntimeError, 'Error: Server temporarily unavailable (Error 500).')
+    end
+
+    it 'raises on 503' do
+      expect { described_class.handle_response(fake_response(503)) }
+        .to raise_error(RuntimeError, /Locked/)
+    end
+  end
+
+  describe '.status_label' do
+    def fake_response(code, body = '{}')
+      instance_double(Net::HTTPResponse, code: code.to_s, body: body)
+    end
+
+    it 'returns success OK for 200' do
+      expect(described_class.status_label(fake_response(200))).to include('OK')
+    end
+
+    it 'returns success Created for 201' do
+      expect(described_class.status_label(fake_response(201))).to include('Created')
+    end
+
+    it 'returns success Accepted for 202' do
+      expect(described_class.status_label(fake_response(202))).to include('Accepted')
+    end
+
+    it 'returns success Not Modified for 304' do
+      expect(described_class.status_label(fake_response(304))).to include('Not Modified')
+    end
+
+    it 'returns failure with error message for 4xx' do
+      body = MultiJson.dump('error' => 'Bad request')
+      expect(described_class.status_label(fake_response(400, body))).to include('Bad request')
+    end
+
+    it 'returns failure for 500' do
+      expect(described_class.status_label(fake_response(500))).to include('Server temporarily unavailable')
+    end
+
+    it 'returns failure with Locked for 503' do
+      expect(described_class.status_label(fake_response(503))).to include('Locked')
     end
   end
 end


### PR DESCRIPTION
handle_response mixed concerns: 6+ branches, 3 return types, and 2 boolean flags controlling behavior. Split into single-responsibility methods:

- handle_response(response): raises on error, returns response body
- status_label(response): returns formatted display string for UI
- raise_on_error!(response): private, shared error-checking logic

Other improvements:
- Project.fetch_info now uses handle_response instead of puts + exit 1
- TranslationFile: extract with_display helper to remove repeated retry/rescue/Result boilerplate across fetch, upload, create, delete
- with_retries: interpolate actual delay value in timeout message
- Use instance_double(Net::HTTPResponse) in specs for verified doubles

Closes #423